### PR TITLE
Add xterm to XMonad dependencies

### DIFF
--- a/x11-wm/xmonad/xmonad-0.10.ebuild
+++ b/x11-wm/xmonad/xmonad-0.10.ebuild
@@ -21,7 +21,8 @@ IUSE=""
 RDEPEND="dev-haskell/mtl
 		=dev-haskell/utf8-string-0.3*
 		=dev-haskell/x11-1.5*
-		>=dev-lang/ghc-6.10.1"
+		>=dev-lang/ghc-6.10.1
+		x11-terms/xterm"
 DEPEND="${RDEPEND}
 		>=dev-haskell/cabal-1.2"
 


### PR DESCRIPTION
I managed to emerge XMonad without ever having emerged xterm. This causes a... less than desirable initial user experience.

The mouse cursor moved around nicely, though....
