### PR TITLE
GHC 7.4.2 starter binary requires glibc 2.14

### DIFF
--- a/dev-lang/ghc/ghc-7.4.2.ebuild
+++ b/dev-lang/ghc/ghc-7.4.2.ebuild
@@ -98,7 +98,8 @@ DEPEND="${RDEPEND}
 				doc? (	app-text/docbook-xml-dtd:4.2
 				app-text/docbook-xml-dtd:4.5
 				app-text/docbook-xsl-stylesheets
-				>=dev-libs/libxslt-1.1.2 ) )"
+				>=dev-libs/libxslt-1.1.2 ) )
+	!ghcbootstrap? ( >=sys-libs/glibc-2.14 )"
 # In the ghcbootstrap case we rely on the developer having
 # >=ghc-5.04.3 on their $PATH already
 


### PR DESCRIPTION
Though Gentoo has >=sys-libs/glibc-2.14 stabilized, Funtoo is still using sys-libs/glibc-2.13 . It would be nice if the dependency of GHC on glibc 2.14 (when not using USE=ghcbootstrap) could be made explicit.
