### PR TITLE
sci-mathematics/agda: Add patch to deal with quichcheck update

### DIFF
--- a/sci-mathematics/agda/files/agda-2.3.0.1-quickcheck-2.5.patch
+++ b/sci-mathematics/agda/files/agda-2.3.0.1-quickcheck-2.5.patch
@@ -9,3 +9,22 @@
                      haskell-src-exts >= 1.9.6 && < 1.14,
                      containers >= 0.1 && < 0.5,
                      pretty >= 1.0 && < 1.2,
+--- Agda-2.3.0.1-orig/src/full/Agda/Termination/Lexicographic.hs	2012-11-09 03:23:20.938830800 +0900
++++ Agda-2.3.0.1/src/full/Agda/Termination/Lexicographic.hs	2012-11-09 03:22:25.918728273 +0900
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ -- | Lexicographic order search, more or less as defined in
+ --      \"A Predicative Analysis of Structural Recursion\" by
+ --      Andreas Abel and Thorsten Altenkirch.
+@@ -230,7 +231,11 @@
+   , quickCheck' prop_fromDiagonals
+   , quickCheck' prop_newBehaviour
+   , quickCheckWith' stdArgs{ maxSuccess = 50
++#if MIN_VERSION_QuickCheck(2,5,0)
++                           , maxDiscardRatio = 4
++#else
+                            , maxDiscard = 200
++#endif
+                            , maxSize    = 20
+                            }
+                     prop_lexOrder


### PR DESCRIPTION
Currently sci-mathematics/agda fail due to with the following error, due to QuickCheck's API change.

[126 of 232] Compiling Agda.Termination.Lexicographic ( src/full/Agda/Termination/Lexicographic.h

src/full/Agda/Termination/Lexicographic.hs:233:30:
    `maxDiscard' is not a (visible) constructor field name

files/agda-2.3.0.1-quickcheck-2.5.patch allows agda to be built with quickcheck-2.5. However it doesn't update the code. This patch import the upstream patch to deal with its API change.
