### PR TITLE
Fix ghc-9999 ebuild

### DIFF
--- a/dev-lang/ghc/ghc-9999.ebuild
+++ b/dev-lang/ghc/ghc-9999.ebuild
@@ -440,7 +440,7 @@ src_install() {
 		echo "${GHC_PV}" > "${S}/VERSION" \
 			|| die "Could not create file ${S}/VERSION"
 	fi
-	dodoc "${S}/README" "${S}/ANNOUNCE" "${S}/LICENSE" "${S}/VERSION"
+	dodoc "${S}/README.md" "${S}/ANNOUNCE" "${S}/LICENSE" "${S}/VERSION"
 
 	dobashcomp "${FILESDIR}/ghc-bash-completion"
 


### PR DESCRIPTION
GHC converted its readme to markdown, this causes installation to fail with
`dodoc: /var/tmp/portage/dev-lang/ghc-9999/work/ghc-9999/README does not exist`
