### PR TITLE
Update Qt dependency names

### DIFF
--- a/dev-haskell/hsqml/hsqml-0.1.1.ebuild
+++ b/dev-haskell/hsqml/hsqml-0.1.1.ebuild
@@ -24,7 +24,7 @@ RDEPEND=">=dev-haskell/network-2.3:=[profile?]
 		>=dev-haskell/transformers-0.2:=[profile?]
 		<dev-haskell/transformers-0.4:=[profile?]
 		>=dev-lang/ghc-7.4.1:=
-		x11-libs/qt-declarative"
+		dev-qt/qtdeclarative"
 DEPEND="${RDEPEND}
 		dev-haskell/c2hs
 		>=dev-haskell/cabal-1.10

--- a/dev-haskell/qthaskellc/qthaskellc-1.1.4.ebuild
+++ b/dev-haskell/qthaskellc/qthaskellc-1.1.4.ebuild
@@ -22,10 +22,10 @@ IUSE="debug"
 DOCS="${WORKDIR}/${MY_P}/INSTALL ${WORKDIR}/${MY_P}/LICENSE ${WORKDIR}/${MY_P}/README"
 
 DEPEND="virtual/opengl
-		x11-libs/qt-core:4
-		x11-libs/qt-gui:4
-		x11-libs/qt-opengl:4
-		x11-libs/qt-script:4"
+		dev-qt/qtcore:4
+		dev-qt/qtgui:4
+		dev-qt/qtopengl:4
+		dev-qt/qtscript:4"
 
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Gentoo moved x11-libs/qt-\* to dev-qt/qt\* in 1Q-2013
