### PR TITLE
Fix xmobar-0.18 build

### DIFF
--- a/x11-misc/xmobar/xmobar-0.18.ebuild
+++ b/x11-misc/xmobar/xmobar-0.18.ebuild
@@ -18,7 +18,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 #hackport: ignore-use all_extansions
 #hackport: rename-use with_alsa alsa
-#hackport: rename-use with_timezone timezone
+#hackport: rename-use with_datezone timezone
 #hackport: rename-use with_threaded threaded
 #hackport: rename-use with_dbus dbus
 IUSE="alsa timezone threaded dbus inotify wifi mpd mpris mail xft"
@@ -58,7 +58,7 @@ src_configure() {
 	haskell-cabal_src_configure \
 		--flags=with_utf8 \
 		$(cabal_flag alsa with_alsa) \
-		$(cabal_flag datezone with_datezone) \
+		$(cabal_flag timezone with_datezone) \
 		$(cabal_flag dbus with_dbus) \
 		$(cabal_flag inotify with_inotify) \
 		$(cabal_flag wifi with_iwlib) \


### PR DESCRIPTION
I can't emerge xmobar-0.18 since 'datezone' is not in IUSE

I fix xmobar-0.18.ebuild in the same way as xmobar-0.17.ebuild.
