### PR TITLE
dev-haskell/alex: fix build failure

### DIFF
--- a/dev-haskell/alex/alex-3.0.5.ebuild
+++ b/dev-haskell/alex/alex-3.0.5.ebuild
@@ -28,7 +28,7 @@ DEPEND="${RDEPEND}
 		>=dev-libs/libxslt-1.1.2 )"
 
 src_prepare() {
-	HCFLAGS+=-XBangPatterns #fixes build failure on BE platforms; bug 466778
+	HCFLAGS+=" -XBangPatterns" #fixes build failure on BE platforms; bug 466778
 
 	cabal_chdeps \
 		'build-depends: process' 'build-depends: process, base'


### PR DESCRIPTION
if the user has HCFLAGS="foo" in make.conf, the
previous syntax will produce a build failure
