### PR TITLE
dev-haskell/sdl-ttf should depend on media-libs/sdl-ttf

### DIFF
--- a/dev-haskell/sdl-ttf/sdl-ttf-0.6.2-r1.ebuild
+++ b/dev-haskell/sdl-ttf/sdl-ttf-0.6.2-r1.ebuild
@@ -22,7 +22,8 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/sdl:=[profile?]
-		>=dev-lang/ghc-6.10.4:="
+		>=dev-lang/ghc-6.10.4:=
+		media-libs/sdl-ttf"
 DEPEND="${RDEPEND}
 		>=dev-haskell/cabal-1.6"
 


### PR DESCRIPTION
The patch records the missing dependency.
