### PR TITLE
app-emacs/ghc-mod: bump up to 3.0.0-r1

### DIFF
--- a/app-emacs/ghc-mod/ghc-mod-3.0.0-r1.ebuild
+++ b/app-emacs/ghc-mod/ghc-mod-3.0.0-r1.ebuild
@@ -19,7 +19,6 @@ KEYWORDS="~amd64 ~x86"
 IUSE="emacs"
 
 RDEPEND="emacs? ( virtual/emacs )
-		app-emacs/ghc-mod:=[profile?]
 		>=dev-haskell/cabal-1.10:=[profile?]
 		dev-haskell/convertible:=[profile?]
 		dev-haskell/ghc-paths:=[profile?]


### PR DESCRIPTION
fix: circular dependencies
