### PR TITLE
sci-mathematics/agda-stdlib: Install agda-lib-ffi

### DIFF
--- a/sci-mathematics/agda-stdlib/agda-stdlib-0.7.ebuild
+++ b/sci-mathematics/agda-stdlib/agda-stdlib-0.7.ebuild
@@ -28,6 +28,14 @@ src_prepare() {
 	cabal-mksetup
 }
 
+src_configure() {
+	haskell-cabal_src_configure
+	pushd "${S}/ffi"
+	cabal-bootstrap
+	cabal-configure
+	popd
+}
+
 src_compile() {
 	haskell-cabal_src_compile
 	"${S}"/dist/build/GenerateEverything/GenerateEverything \
@@ -44,6 +52,9 @@ src_compile() {
 	# /usr/share/agda-9999/ghc-7.4.1/Agda.css: copyFile: does not exist
 	local cssdir=$(egrep 'datadir *=' "${S}/dist/build/autogen/Paths_lib.hs" | sed -e 's@datadir    = \(.*\)@\1@')
 	agda --html -i "${S}" -i "${S}"/src --css="${cssdir}/Agda.css" "${S}"/README.agda || die
+	pushd "${S}/ffi"
+	cabal_src_compile
+	popd
 }
 
 src_test() {
@@ -56,4 +67,7 @@ src_install() {
 	doins -r src/*
 	dodoc -r html/*
 	elisp-site-file-install "${FILESDIR}/${SITEFILE}" || die
+	pushd "${S}/ffi"
+	cabal_src_install
+	popd
 }

--- a/sci-mathematics/agda-stdlib/agda-stdlib-9999.ebuild
+++ b/sci-mathematics/agda-stdlib/agda-stdlib-9999.ebuild
@@ -39,6 +39,14 @@ src_prepare() {
 	cabal-mksetup
 }
 
+src_configure() {
+	haskell-cabal_src_configure
+	pushd "${S}/ffi"
+	cabal-bootstrap
+	cabal-configure
+	popd
+}
+
 src_compile() {
 	haskell-cabal_src_compile
 	"${S}"/dist/build/GenerateEverything/GenerateEverything \
@@ -55,6 +63,9 @@ src_compile() {
 	# /usr/share/agda-9999/ghc-7.4.1/Agda.css: copyFile: does not exist
 	local cssdir=$(egrep 'datadir *=' "${S}/dist/build/autogen/Paths_lib.hs" | sed -e 's@datadir    = \(.*\)@\1@')
 	agda --html -i "${S}" -i "${S}"/src --css="${cssdir}/Agda.css" "${S}"/README.agda || die
+	pushd "${S}/ffi"
+	cabal_src_compile
+	popd
 }
 
 src_test() {
@@ -67,4 +78,7 @@ src_install() {
 	doins -r src/*
 	dodoc -r html/*
 	elisp-site-file-install "${FILESDIR}/${SITEFILE}" || die
+	pushd "${S}/ffi"
+	cabal_src_install
+	popd
 }


### PR DESCRIPTION
The agda-lib-ffi package provides some additional haskell modules which
are needed by the agda standard library, such as during compilation
using the MAlonzo backend. It is available inside the ffi/ directory and
needs to be built and installed by the ebuild. This patch does that.
