### PR TITLE
dev-haskell/aeson: add dependency to dlist

### DIFF
--- a/dev-haskell/aeson/aeson-0.6.2.1.ebuild
+++ b/dev-haskell/aeson/aeson-0.6.2.1.ebuild
@@ -21,6 +21,7 @@ IUSE="developer"
 RDEPEND=">=dev-haskell/attoparsec-0.8.6.1:=[profile?]
 	>=dev-haskell/blaze-builder-0.2.1.4:=[profile?]
 	dev-haskell/deepseq:=[profile?]
+	>=dev-haskell/dlist-0.2:=[profile?]
 	>=dev-haskell/hashable-1.1.2.0:=[profile?]
 	dev-haskell/mtl:=[profile?]
 	dev-haskell/syb:=[profile?]


### PR DESCRIPTION
Dependency got lost with the version bump. It already had been added manually to the previous version.
