### PR TITLE
Removes dependency on ghc-syb that, according to Hackage, doesn't exist.

### DIFF
--- a/dev-haskell/ghc-syb-utils/ghc-syb-utils-0.2.1.2.ebuild
+++ b/dev-haskell/ghc-syb-utils/ghc-syb-utils-0.2.1.2.ebuild
@@ -18,8 +18,7 @@ SLOT="0/${PV}"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-RDEPEND=">=dev-haskell/ghc-syb-0.2:=[profile?] <dev-haskell/ghc-syb-0.3:=[profile?]
-	>=dev-haskell/syb-0.1.0:=[profile?]
+RDEPEND=">=dev-haskell/syb-0.1.0:=[profile?]
 	>=dev-lang/ghc-6.10.4:=
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
After update of the ghc-syb-utils (from 0.2.1.1 to 0.2.1.2) ghc-mod fails to build under ghc-7.6.3. The reason, I think, is that the new version of ghc-syb-utils imposes a dependency on ghc-syb that according to hackage doesn't exist.
