### PR TITLE
eclass/haskell-cabal.eclass: Set --sysconfdir in Cabal's configure step.

### DIFF
--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -383,6 +383,7 @@ cabal-configure() {
 		--libsubdir=${P}/ghc-$(ghc-version) \
 		--datadir="${EPREFIX}"/usr/share/ \
 		--datasubdir=${P}/ghc-$(ghc-version) \
+		--sysconfdir="${EPREFIX}"/etc \
 		${cabalconf} \
 		${CABAL_CONFIGURE_FLAGS} \
 		${CABAL_EXTRA_CONFIGURE_FLAGS} \


### PR DESCRIPTION
It was set to $EPREFIX/usr/etc, now it's $EPREFIX/etc.
