### PR TITLE
Added regex-compat to dependencies

### DIFF
--- a/x11-misc/xmobar/xmobar-9999.ebuild
+++ b/x11-misc/xmobar/xmobar-9999.ebuild
@@ -24,6 +24,7 @@ DEPEND="${RDEPEND}
 		>=dev-haskell/cabal-1.6
 		>=dev-haskell/mtl-2.0 <dev-haskell/mtl-2.2
 		>=dev-haskell/parsec-3
+		dev-haskell/regex-compat
 		>=dev-haskell/stm-2.3 <dev-haskell/stm-2.5
 		=dev-haskell/x11-1.6*
 		xft?  ( =dev-haskell/utf8-string-0.3*


### PR DESCRIPTION
Build fails with message:
...
Configuring xmobar-0.19...
setup: At least the following dependencies are missing:
regex-compat -any

xmobar itroduced regex-compat dependency with commit https://github.com/jaor/xmobar/commit/85fdac20a36675559802dd215a81f640b91693fe
