### PR TITLE
x11-misc/xmobar-9999: remove KEYWORDS

### DIFF
--- a/x11-misc/xmobar/xmobar-9999.ebuild
+++ b/x11-misc/xmobar/xmobar-9999.ebuild
@@ -16,7 +16,7 @@ EGIT_REPO_URI="git://github.com/jaor/xmobar.git"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS=""
 IUSE="alsa dbus inotify mpd mpris timezone wifi xft"
 
 RDEPEND="x11-libs/libXrandr


### PR DESCRIPTION
Live ebuilds should be either masked or unkeyworded, as they aren't
tested per definitionem.
