### PR TITLE
dev-haskell/quickcheck: Hackport missed dependency on tf-random

### DIFF
--- a/dev-haskell/quickcheck/quickcheck-2.7.3.ebuild
+++ b/dev-haskell/quickcheck/quickcheck-2.7.3.ebuild
@@ -24,6 +24,7 @@ IUSE="+template_haskell"
 
 RDEPEND="dev-haskell/extensible-exceptions:=[profile?]
 	dev-haskell/random:=[profile?]
+	dev-haskell/tf-random:=[profile?]
 	>=dev-lang/ghc-6.10.4:=
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Hackport missed the dependency of quickcheck-2.7.3 on tf-random. The hackport issue should be examined,  but for now, let's just fix the ebuild.
