### PR TITLE
dev-haskell/hdbc: Mask new, API-breaking convertible version

### DIFF
--- a/dev-haskell/hdbc/hdbc-2.3.1.2.ebuild
+++ b/dev-haskell/hdbc/hdbc-2.3.1.2.ebuild
@@ -21,7 +21,7 @@ SLOT="2/${PV}"
 KEYWORDS="~amd64 ~x86"
 IUSE="mysql odbc postgres sqlite3 test"
 
-RDEPEND=">=dev-haskell/convertible-1.0.10.0:=[profile?]
+RDEPEND=">=dev-haskell/convertible-1.0.10.0:=[profile?] <dev-haskell/convertible-1.1.0.0:=[profile?]
 		dev-haskell/mtl:=[profile?]
 		dev-haskell/text:=[profile?]
 		dev-haskell/utf8-string:=[profile?]


### PR DESCRIPTION
There's also the new hdbc-2.4.0.0 which works with convertible-1.1.0.0, however I haven't checked yet if it works with the 2.3 versions of hdbc-postgresql/hdbc-sqlite etc.
