### PR TITLE
Execute show repo command in repository directory

### DIFF
--- a/eclass/darcs.eclass
+++ b/eclass/darcs.eclass
@@ -88,7 +88,7 @@ DEPEND="dev-vcs/darcs
 # @DESCRIPTION:
 # Internal function to determine amount of patches in repository.
 darcs_patchcount() {
-	set -- $(HOME="${EDARCS_TOP_DIR}" ${EDARCS_DARCS_CMD} show repo | grep "Num Patches")
+	set -- $(HOME="${EDARCS_TOP_DIR}" ${EDARCS_DARCS_CMD} show repo --repodir="${EDARCS_TOP_DIR}/${EDARCS_LOCALREPO}" | grep "Num Patches")
 	# handle string like: "    Num Patches: 3860"
 	echo ${3}
 }


### PR DESCRIPTION
When cloning the repo for the first time, in "get" mode, the 
darcs_patchcount() function is executed in the darcs-src/ directory instead of
the darcs-src/$REPO directory. We should ensure the current directory is set
to the correct repository directory inside the function.

Signed-off-by: Vikraman Choudhury vikraman@gentoo.org
