### PR TITLE
parsers fails with attoparsec-0.12

### DIFF
--- a/dev-haskell/parsers/parsers-0.11.0.2.ebuild
+++ b/dev-haskell/parsers/parsers-0.11.0.2.ebuild
@@ -19,7 +19,7 @@ SLOT="0/${PV}"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-RDEPEND=">=dev-haskell/attoparsec-0.11.2:=[profile?] <dev-haskell/attoparsec-0.13:=[profile?]
+RDEPEND=">=dev-haskell/attoparsec-0.11.2:=[profile?] <dev-haskell/attoparsec-0.12:=[profile?]
 	>=dev-haskell/charset-0.3:=[profile?] <dev-haskell/charset-1:=[profile?]
 	>=dev-haskell/parsec-3.1:=[profile?] <dev-haskell/parsec-3.2:=[profile?]
 	>=dev-haskell/text-0.10:=[profile?] <dev-haskell/text-1.2:=[profile?]


### PR DESCRIPTION
``` shell
Preprocessing library parsers-0.11.0.2...

[1 of 8] Compiling Text.Parser.Token.Highlight ( src/Text/Parser/Token/Highlight.hs, dist/build/Text/Parser/Token/Highlight.o )

[2 of 8] Compiling Text.Parser.Permutation ( src/Text/Parser/Permutation.hs, dist/build/Text/Parser/Permutation.o )

[3 of 8] Compiling Text.Parser.Combinators ( src/Text/Parser/Combinators.hs, dist/build/Text/Parser/Combinators.o )

src/Text/Parser/Combinators.hs:376:10:

Not in scope: type constructor or class `Att.Chunk'

src/Text/Parser/Combinators.hs:382:21:

Not in scope: `Att.endOfInput'
```

bug: https://github.com/ekmett/parsers/issues/39
