### PR TITLE
dev-haskell/hdbc-2.4.0.0: Remove obsolete USE flags

### DIFF
--- a/dev-haskell/hdbc/hdbc-2.4.0.0.ebuild
+++ b/dev-haskell/hdbc/hdbc-2.4.0.0.ebuild
@@ -20,7 +20,7 @@ SRC_URI="mirror://hackage/packages/archive/${MY_PN}/${PV}/${MY_P}.tar.gz"
 LICENSE="BSD"
 SLOT="2/${PV}"
 KEYWORDS="~amd64 ~x86"
-IUSE="mysql odbc postgres sqlite3 test"
+IUSE="test"
 
 RDEPEND=">=dev-haskell/convertible-1.1.0.0:=[profile?]
 	dev-haskell/mtl:=[profile?]


### PR DESCRIPTION
Usage of these flags was removed in commit 07bfab9.
