### PR TITLE
fix mtl RDEPEND major version limit

### DIFF
--- a/sci-mathematics/agda/agda-2.4.0.2.ebuild
+++ b/sci-mathematics/agda/agda-2.4.0.2.ebuild
@@ -29,7 +29,7 @@ RDEPEND=">=dev-haskell/binary-0.6:=[profile?] <dev-haskell/binary-0.8:=[profile?
 	>=dev-haskell/hashtables-1.0:=[profile?] <dev-haskell/hashtables-1.2:=[profile?]
 	>=dev-haskell/haskeline-0.7:=[profile?] <dev-haskell/haskeline-0.8:=[profile?]
 	>=dev-haskell/haskell-src-exts-1.9.6:=[profile?] <dev-haskell/haskell-src-exts-1.16:=[profile?]
-	>=dev-haskell/mtl-2.1.1:=[profile?] <dev-haskell/mtl-2.3:=[profile?]
+	>=dev-haskell/mtl-2.1.1:=[profile?] <dev-haskell/mtl-2.2:=[profile?]
 	<dev-haskell/parallel-3.3:=[profile?]
 	>=dev-haskell/quickcheck-2.7.5:2=[profile?] <dev-haskell/quickcheck-2.8:2=[profile?]
 	>=dev-haskell/stmonadtrans-0.3.2:=[profile?] <dev-haskell/stmonadtrans-0.4:=[profile?]


### PR DESCRIPTION
source: https://hackage.haskell.org/package/Agda
