### PR TITLE
dev-haskell/gtk2hs-buildtools: Fix missing dependency on hashtables

### DIFF
--- a/dev-haskell/gtk2hs-buildtools/gtk2hs-buildtools-0.13.0.2.ebuild
+++ b/dev-haskell/gtk2hs-buildtools/gtk2hs-buildtools-0.13.0.2.ebuild
@@ -25,6 +25,7 @@ DEPEND="${RDEPEND}
 	dev-haskell/happy
 	dev-haskell/random
 	>=dev-lang/ghc-7.4.1
+	|| ( ( >=dev-lang/ghc-7.7 dev-haskell/hashtables ) <dev-lang/ghc-7.7 )
 "
 
 src_configure() {


### PR DESCRIPTION
For ghc>=7.7 dev-haskell/hashtables is a dependency
Relevant cabal line: https://github.com/gtk2hs/gtk2hs/blob/master/tools/gtk2hs-buildtools.cabal#L119
