### PR TITLE
dev-haskell/singletons-1.0: Add keywords

### DIFF
--- a/dev-haskell/singletons/singletons-1.0.ebuild
+++ b/dev-haskell/singletons/singletons-1.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS=""
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/mtl-2.1.1:=[profile?]


### PR DESCRIPTION
This ebuild was committed without any keywords, because it depends on
ghc 7.8, which didn't have any keywords at the time. Now that ghc
7.8 has keywords, singletons can get them, too.
