### PR TITLE
Have `hackage` mirror use HTTPS

### DIFF
--- a/profiles/thirdpartymirrors
+++ b/profiles/thirdpartymirrors
@@ -1,1 +1,1 @@
-hackage http://hackage.haskell.org/ http://dev.gentoo.org/~qnikst/hdiff.luite.com/
+hackage https://hackage.haskell.org/ https://dev.gentoo.org/~qnikst/hdiff.luite.com/


### PR DESCRIPTION
This commit changes the URLs in the definition of the `hackage` mirror
to use HTTPS rather than unsecured HTTP.

The changed URLs refer to the domains `hackage.haskell.org` and
`dev.gentoo.org`, which are covered by HTTPS certificates issued by
generally-accepted certificate authorities (GlobalSign and DigiCert,
respectively); hence, I believe that this should be a safe change to
make.

Signed-off-by: 8573 8573dd@gmail.com
