### PR TITLE
dev-haskell/yi-language: fix not well-formed metadata.xml

### DIFF
--- a/dev-haskell/yi-language/metadata.xml
+++ b/dev-haskell/yi-language/metadata.xml
@@ -3,6 +3,6 @@
 <pkgmetadata>
 	<herd>haskell</herd>
 	<longdescription>
-		Collection of language-related Yi libraries: lexers, scanners&
+		Collection of language-related Yi libraries: lexers, scanners…
 	</longdescription>
 </pkgmetadata>


### PR DESCRIPTION
I fixed mistaking '…' for '&'.
If exist not well-formed metadata.xml, 'egencache --repo=gentoo-haskell --update --update-use-local-desc' will fall.
