### PR TITLE
Always fetch app-emacs/haskell-mode-9999 via HTTPS

### DIFF
--- a/app-emacs/haskell-mode/haskell-mode-9999.ebuild
+++ b/app-emacs/haskell-mode/haskell-mode-9999.ebuild
@@ -9,7 +9,7 @@ inherit elisp git-2
 DESCRIPTION="Mode for editing (and running) Haskell programs in Emacs"
 HOMEPAGE="http://projects.haskell.org/haskellmode-emacs/
 	http://www.haskell.org/haskellwiki/Haskell_mode_for_Emacs"
-EGIT_REPO_URI="git://github.com/haskell/haskell-mode.git https://github.com/haskell/haskell-mode.git"
+EGIT_REPO_URI="https://github.com/haskell/haskell-mode.git"
 
 LICENSE="GPL-3"
 SLOT="0"


### PR DESCRIPTION
This commit changes the `EGIT_REPO_URI` of
`app-emacs/haskell-mode-9999` to always use the HTTPS Git transport
protocol, rather than either that or the plain Git transport protocol.

The only reasonable scenario I see in which the plain Git transport
would work and the HTTPS transport wouldn’t is that of HTTPS being
blocked by an attacker wishing to force the download to occur via the
unsecured plain Git transport, enabling the injection of malware.

