### PR TITLE
dev-lang/idris: update 9999 version

### DIFF
--- a/dev-lang/idris/idris-9999.ebuild
+++ b/dev-lang/idris/idris-9999.ebuild
@@ -19,7 +19,7 @@ SLOT="0/${PV}"
 #KEYWORDS="~amd64 ~x86"
 IUSE="curses ffi gmp"
 
-RDEPEND=">=dev-haskell/annotated-wl-pprint-0.5.3:=[profile?] <dev-haskell/annotated-wl-pprint-0.6:=[profile?]
+RDEPEND=">=dev-haskell/annotated-wl-pprint-0.5.3:=[profile?] <dev-haskell/annotated-wl-pprint-0.7:=[profile?]
 	<dev-haskell/ansi-terminal-0.7:=[profile?]
 	<dev-haskell/ansi-wl-pprint-0.7:=[profile?]
 	<dev-haskell/base64-bytestring-1.1:=[profile?]
@@ -29,7 +29,7 @@ RDEPEND=">=dev-haskell/annotated-wl-pprint-0.5.3:=[profile?] <dev-haskell/annota
 	<dev-haskell/cheapskate-0.2:=[profile?]
 	>=dev-haskell/fingertree-0.1:=[profile?] <dev-haskell/fingertree-0.2:=[profile?]
 	>=dev-haskell/haskeline-0.7:=[profile?] <dev-haskell/haskeline-0.8:=[profile?]
-	>=dev-haskell/lens-4.1.1:=[profile?]
+	>=dev-haskell/lens-4.1.1:=[profile?] <dev-haskell/lens-4.12:=[profile?]
 	>=dev-haskell/mtl-2.1:=[profile?] <dev-haskell/mtl-2.3:=[profile?]
 	<dev-haskell/network-2.7:=[profile?]
 	>=dev-haskell/optparse-applicative-0.11:=[profile?] <dev-haskell/optparse-applicative-0.12:=[profile?]
@@ -45,9 +45,9 @@ RDEPEND=">=dev-haskell/annotated-wl-pprint-0.5.3:=[profile?] <dev-haskell/annota
 	dev-haskell/utf8-string:=[profile?]
 	<dev-haskell/vector-0.11:=[profile?]
 	<dev-haskell/vector-binary-instances-0.3:=[profile?]
-	<dev-haskell/xml-1.4:=[profile?]
 	<dev-haskell/zlib-0.6:=[profile?]
-	>=dev-lang/ghc-7.6.1:=
+	>=dev-haskell/zip-archive-0.2.3.5:=[profile?]
+	>=dev-lang/ghc-7.10.2:=
 	curses? ( <dev-haskell/hscurses-1.5:=[profile?] )
 	ffi? ( <dev-haskell/libffi-0.2:=[profile?] )
 	gmp? ( <dev-haskell/libffi-0.2:=[profile?] )
@@ -57,10 +57,8 @@ DEPEND="${RDEPEND}
 "
 
 src_prepare() {
-	cabal_chdeps \
-		'utf8-string < 0.4' 'utf8-string' \
-		'blaze-markup >= 0.5.2.1 && < 0.6.3.0' 'blaze-markup' \
-		'blaze-html >= 0.6.1.3 && < 0.8' 'blaze-html >= 0.6.1.3'
+	# runs dist/build/idris directly and breaks sandboxing
+	export LD_LIBRARY_PATH="${S}/dist/build${LD_LIBRARY_PATH+:}${LD_LIBRARY_PATH}"
 }
 
 src_configure() {
@@ -71,5 +69,5 @@ src_configure() {
 		$(cabal_flag ffi ffi) \
 		--flag=-freestanding \
 		$(cabal_flag gmp gmp) \
-		--flag=release
+		--flag=-release
 }


### PR DESCRIPTION
**[DO NOT MERGE YET]**

It works fine with ghc 7.10.2, unfortunately, there's some issue:

```
../../dist/build/idris/idris: error while loading shared libraries: libHSidris-0.9.18.1-7S2dH0MQ9Dd1NbPfauOd39-ghc7.10.2.so: cannot open shared object file: No such file or directory
```

How can I build idris statically?