### PR TITLE
Add pipes-4.1 to the dependency of app-emacs/ghc-mod-9999

### DIFF
--- a/app-emacs/ghc-mod/ghc-mod-9999.ebuild
+++ b/app-emacs/ghc-mod/ghc-mod-9999.ebuild
@@ -40,6 +40,7 @@ RDEPEND="dev-haskell/async:=[profile?]
 	dev-haskell/text:=[profile?]
 	dev-haskell/transformers:=[profile?]
 	dev-haskell/transformers-base:=[profile?]
+	>=dev-haskell/pipes-4.1:=[profile?]
 	>=dev-lang/ghc-7.4.1:=
 	dev-haskell/ghc-api
 "


### PR DESCRIPTION
With this change, now I can emerge ghc-mod-9999 successfully.
I have tested with ghc-7.10.2-r1::gentoo.

The following is the error log that emerging ghc-mod-9999 generated.
~~~
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) app-emacs/ghc-mod-9999::haskell
>>> Failed to emerge app-emacs/ghc-mod-9999, Log file:
>>>  '/tmp/portage/app-emacs/ghc-mod-9999/temp/build.log'
 * Package:    app-emacs/ghc-mod-9999
 * Repository: haskell
 * Maintainer: haskell@gentoo.org
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux userland_GNU
 * FEATURES:   preserve-libs sandbox splitdebug userpriv usersandbox
GIT update -->
   repository:               https://github.com/kazu-yamamoto/ghc-mod.git
   at the commit:            0fde762500016d00ff3bed32d8dfca6e1b351b55
   branch:                   master
   storage directory:        "/usr/portage/distfiles/egit-src/ghc-mod.git"
   checkout type:            bare repository
Cloning into '/tmp/portage/app-emacs/ghc-mod-9999/work/ghc-mod-9999'...
done.
Branch branch-master set up to track remote branch master from origin.
Switched to a new branch 'branch-master'
>>> Unpacked to /tmp/portage/app-emacs/ghc-mod-9999/work/ghc-mod-9999
 * Applying ghc-mod-9999-gentoo.patch ...
 [ ok ]
 * Using cabal-1.22.4.0.
 * Prepending /usr/lib64/ghc-7.10.2 to LD_LIBRARY_PATH
/usr/bin/ghc -package Cabal-1.22.4.0 --make /tmp/portage/app-emacs/ghc-mod-9999/work/ghc-mod-9999/Setup.hs -threaded -dynamic -o setup
[1 of 5] Compiling NotCPP.Utils     ( NotCPP/Utils.hs, NotCPP/Utils.o )
[2 of 5] Compiling NotCPP.LookupValueName ( NotCPP/LookupValueName.hs, NotCPP/LookupValueName.o )
[3 of 5] Compiling NotCPP.Declarations ( NotCPP/Declarations.hs, NotCPP/Declarations.o )
[4 of 5] Compiling SetupCompat      ( SetupCompat.hs, SetupCompat.o )
[5 of 5] Compiling Main             ( /tmp/portage/app-emacs/ghc-mod-9999/work/ghc-mod-9999/Setup.hs, /tmp/portage/app-emacs/ghc-mod-9999/work/ghc-mod-9999/Setup.o )
Linking setup ...
./setup configure --ghc --prefix=/usr --with-compiler=/usr/bin/ghc --with-hc-pkg=/usr/bin/ghc-pkg --prefix=/usr --libdir=/usr/lib64 --libsubdir=ghc-mod-9999/ghc-7.10.2 --datadir=/usr/share/ --datasubdir=ghc-mod-9999/ghc-7.10.2 --disable-tests --ghc-option=-j4 --ghc-option=-optc-march=native --ghc-option=-optc-O2 --ghc-option=-optc-pipe --ghc-option=-optl-Wl,-O1 --ghc-option=-optl-Wl,--as-needed --disable-executable-stripping --docdir=/usr/share/doc/ghc-mod-9999 --verbose --enable-shared --enable-executable-dynamic --sysconfdir=/etc --disable-library-stripping
Configuring ghc-mod-5.4.0.0...
setup: At least the following dependencies are missing:
pipes ==4.1.*
 * ghc-pkg check: 'checking for other broken packages:'
There are problems in package ghc-mod-5.3.0.0:
  Warning: haddock-interfaces: /usr/share/doc/ghc-mod-9999/html/ghc-mod.haddock doesn't exist or isn't a file
  Warning: haddock-html: /usr/share/doc/ghc-mod-9999/html doesn't exist or isn't a directory
  dependency "monad-journal-0.7.1-3432cb6c5d4e6906f997bf6b9e465e03" doesn't exist

The following packages are broken, either because they have a problem
listed above, or because they depend on a broken package.
ghc-mod-5.3.0.0
 * Detected broken packages: ghc-mod-5.3.0.0
 * ERROR: app-emacs/ghc-mod-9999::haskell failed (configure phase):
 *   //==-- Please, run 'haskell-updater' to fix broken packages --==//
 *
 * Call stack:
 *     ebuild.sh, line   93:  Called src_configure
 *   environment, line 3470:  Called haskell-cabal_src_configure
 *   environment, line 2579:  Called cabal-configure
 *   environment, line  742:  Called cabal-show-brokens-and-die 'setup configure failed'
 *   environment, line  838:  Called cabal-show-brokens
 *   environment, line  834:  Called cabal-die-if-nonempty 'broken' 'ghc-mod-5.3.0.0'
 *   environment, line  764:  Called die
 * The specific snippet of code:
 *       die "//==-- Please, run 'haskell-updater' to fix ${breakage_type} packages --==//"
 *
 * If you need support, post the output of `emerge --info '=app-emacs/ghc-mod-9999::haskell'`,
 * the complete build log and the output of `emerge -pqv '=app-emacs/ghc-mod-9999::haskell'`.
 * The complete build log is located at '/tmp/portage/app-emacs/ghc-mod-9999/temp/build.log'.
 * The ebuild environment file is located at '/tmp/portage/app-emacs/ghc-mod-9999/temp/environment'.
 * Working directory: '/tmp/portage/app-emacs/ghc-mod-9999/work/ghc-mod-9999'
 * S: '/tmp/portage/app-emacs/ghc-mod-9999/work/ghc-mod-9999'
~~~