### PR TITLE
dev-haskell/cairo-0.13.3.0: Re-add dep on gtk2hs-buildtools

### DIFF
--- a/dev-haskell/cairo/cairo-0.13.3.0.ebuild
+++ b/dev-haskell/cairo/cairo-0.13.3.0.ebuild
@@ -27,6 +27,7 @@ RDEPEND="dev-haskell/mtl:=[profile?]
 "
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-1.24
+	dev-haskell/gtk2hs-buildtools
 	virtual/pkgconfig
 "
 


### PR DESCRIPTION
dev-haskell/cairo requires dev-haskell/gtk2hs-buildtools for
compilation, but this dependency has been accidentally removed from the
ebuild during the bump to 0.13.3.0