### PR TITLE
x11-misc/taffybar: refresh live ebuild

### DIFF
--- a/x11-misc/taffybar/taffybar-9999.ebuild
+++ b/x11-misc/taffybar/taffybar-9999.ebuild
@@ -20,6 +20,7 @@ IUSE="+network-uri"
 RDEPEND="dev-haskell/cairo:=[profile?]
 	>=dev-haskell/dbus-0.10.7:=[profile?] <dev-haskell/dbus-1.0:=[profile?]
 	>=dev-haskell/dyre-0.8.6:=[profile?] <dev-haskell/dyre-0.9:=[profile?]
+	>=dev-haskell/either-4.0.0.0:=[profile?]
 	>=dev-haskell/enclosed-exceptions-1.0.0.1:=[profile?]
 	>=dev-haskell/gtk-0.12.1:=[profile?] <dev-haskell/gtk-0.15:=[profile?]
 	>=dev-haskell/gtk-traymanager-0.1.2:=[profile?] <dev-haskell/gtk-traymanager-0.2:=[profile?]


### PR DESCRIPTION
Add dependency on dev-haskell/either.

See: https://github.com/travitch/taffybar/commit/ce0816296f63711dac05ff005768203e31f9ab39