### PR TITLE
Modify hackage mirrors for https://bugs.gentoo.org/644382

### DIFF
--- a/profiles/thirdpartymirrors
+++ b/profiles/thirdpartymirrors
@@ -1,1 +1,1 @@
-hackage https://hackage.haskell.org/ https://dev.gentoo.org/~qnikst/hdiff.luite.com/
+hackage https://hackage.haskell.org/


### PR DESCRIPTION
This is related to https://bugs.gentoo.org/644382 and https://github.com/gentoo-haskell/gentoo-haskell/issues/660 . Another pull request for the main Portage tree has been opened as well: https://github.com/gentoo/gentoo/pull/6850

The hackport line in profiles/thirdpartymirrors is currently as follows:

`hackage http://hackage.haskell.org/ https://dev.gentoo.org/~qnikst/hdiff.luite.com/`

There are two problems with this:
1. `hackage.haskell.org` supports HTTPS and so this URL should be switched to `https://hackage.haskell.org/` (This has already been fixed in the haskell overlay)
2. The second mirror is currently redirecting all requests to `http://hdiff.luite.com/`. `hdiff.luite.com` does not have working HTTPS and so this second mirror should be removed as it misleads devs into thinking this mirror will provide encryption.