### PR TITLE
Add repoman to dependencies for hackport

### DIFF
--- a/app-portage/hackport/hackport-0.5.2.ebuild
+++ b/app-portage/hackport/hackport-0.5.2.ebuild
@@ -19,7 +19,8 @@ IUSE=""
 
 RESTRICT=test # tests are broken: need path to ebuild tree
 
-RDEPEND="dev-haskell/async:=
+RDEPEND="|| ( <sys-apps/portage-2.3.0 app-portage/repoman )
+	dev-haskell/async:=
 	dev-haskell/base16-bytestring:=
 	dev-haskell/base64-bytestring:=
 	dev-haskell/cryptohash:=

--- a/app-portage/hackport/hackport-0.5.3.ebuild
+++ b/app-portage/hackport/hackport-0.5.3.ebuild
@@ -19,7 +19,8 @@ IUSE=""
 
 RESTRICT=test # tests are broken: need path to ebuild tree
 
-RDEPEND="dev-haskell/async:=
+RDEPEND="|| ( <sys-apps/portage-2.3.0 app-portage/repoman )
+	dev-haskell/async:=
 	dev-haskell/base16-bytestring:=
 	dev-haskell/base64-bytestring:=
 	dev-haskell/cryptohash:=

--- a/app-portage/hackport/hackport-0.5.4.ebuild
+++ b/app-portage/hackport/hackport-0.5.4.ebuild
@@ -19,7 +19,8 @@ IUSE=""
 
 RESTRICT=test # tests are broken: need path to ebuild tree
 
-RDEPEND="dev-haskell/async:=
+RDEPEND="|| ( <sys-apps/portage-2.3.0 app-portage/repoman )
+	dev-haskell/async:=
 	dev-haskell/base16-bytestring:=
 	dev-haskell/base64-bytestring:=
 	dev-haskell/cryptohash:=

--- a/app-portage/hackport/hackport-9999.ebuild
+++ b/app-portage/hackport/hackport-9999.ebuild
@@ -20,7 +20,8 @@ IUSE=""
 
 RESTRICT=test # tests are broken: need path to ebuild tree
 
-RDEPEND="dev-haskell/async:=
+RDEPEND="|| ( <sys-apps/portage-2.3.0 app-portage/repoman )
+	dev-haskell/async:=
 	dev-haskell/base16-bytestring:=
 	dev-haskell/base64-bytestring:=
 	dev-haskell/cryptohash:=


### PR DESCRIPTION
While most devs will already have repoman merged, listing it explicitly makes it that much smoother for newcomers (like me). Besides, it allows dropping it from `@world` if anyone doesn't use it directly.

repoman itself complains about the <sys-apps/portage-2.3.0 not matching any packages, but I thought it would be better to leave it in for the out-of-date repos that do still provide early versions.