### PR TITLE
dev-lang/elm-reactor: add missing dependency on elm-make

### DIFF
--- a/dev-lang/elm-reactor/elm-reactor-0.18.0.ebuild
+++ b/dev-lang/elm-reactor/elm-reactor-0.18.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -37,4 +37,5 @@ RDEPEND=">=dev-haskell/aeson-0.7:=
 "
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-1.18.1.3
+	~dev-lang/elm-make-${PV}
 "


### PR DESCRIPTION
Add a build-time dependency on elm-make to avoid the error below. Fixed in-place because this is a build error and it may not have affected people because it depends on the merge order.

>> Compiling source in /var/tmp/portage/dev-lang/elm-reactor-0.18.0/work/elm-reactor-0.18.0 ...
./setup build
Building elm-reactor-0.18...
Preprocessing executable 'elm-reactor' for elm-reactor-0.18...
[1 of 8] Compiling StaticFiles.Build ( src/backend/StaticFiles/Build.hs, dist/build/elm-reactor/elm-reactor-tmp/StaticFiles/Build.dyn_o )
[2 of 8] Compiling StaticFiles      ( src/backend/StaticFiles.hs, dist/build/elm-reactor/elm-reactor-tmp/StaticFiles.dyn_o )

src/backend/StaticFiles.hs:50:3: error:
    • Exception when trying to run compile-time code:
        elm-make: readCreateProcessWithExitCode: runInteractiveProcess: exec: does not exist (No such file or directory)
      Code: (=<<)
              bsToExp runIO (Build.compile ("src" </> "pages" </> "Errors.elm"))
    • In the untyped splice:
        $(bsToExp
          =<< runIO (Build.compile ("src" </> "pages" </> "Errors.elm")))
[3 of 8] Compiling Socket           ( src/backend/Socket.hs, dist/build/elm-reactor/elm-reactor-tmp/Socket.dyn_o )

src/backend/Socket.hs:15:11: warning: [-Wunused-matches]
    Defined but not used: ‘watchedFile’
[4 of 8] Compiling Generate.Help    ( src/backend/Generate/Help.hs, dist/build/elm-reactor/elm-reactor-tmp/Generate/Help.dyn_o )
