### PR TITLE
eclass/ghc-package.eclass: fix ghc-install-pkg failure to register

### DIFF
--- a/eclass/ghc-package.eclass
+++ b/eclass/ghc-package.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: ghc-package.eclass
@@ -261,8 +261,8 @@ ghc-install-pkg() {
 
 	$(ghc-getghcpkgbin) init "${localpkgconf}" || die "Failed to initialize empty local db"
 	for pkg_config_file in "$@"; do
-		$(ghc-getghcpkgbin) -f "${localpkgconf}" update - --force \
-				< "${pkg_config_file}" || die "failed to register ${pkg}"
+		$(ghc-getghcpkgbin) -f "${localpkgconf}" update --force \
+				"${pkg_config_file}" || die "failed to register ${pkg}"
 	done
 
 	check-for-collisions "${localpkgconf}"


### PR DESCRIPTION
Prior to this patch, `ghc-install-pkg` dies when installing
dev-haskell/haddock-library-1.6.0. The function dies trying to read
from stdin with the `getContents` function, called in the `registerPackage`
function of ghc-pkg, because it tries to read a directory rather than a file.
I have yet to determine the exact cause of this.

This patch changes the behaviour of the `ghc-install-pkg` function such
that instead of pushing `${pkg_config_file}` onto stdin and instructing
the `registerPackage` function of ghc-pkg to call `hGetContents stdin`,
`ghc-install-pkg` now pushes `${pkg_config_file}` directly into ghc-pkg's
`registerPackage` function, resulting in the `readutf8file` function being
called directly on `${pkg_config_file}`.

This allows `ghc-install-pkg` to successfully register haddock-library-1.6.0
and allows the merge to complete successfully.

I have tested this patch on only a few other packages, and I have come
across no issues. Haskell-updater and revdep-rebuild both report no issues.