### PR TITLE
dev-haskell/repa: correct upper bound on base dependency in 3.4.1.3-r1

### DIFF
--- a/dev-haskell/repa/repa-3.4.1.3-r1.ebuild
+++ b/dev-haskell/repa/repa-3.4.1.3-r1.ebuild
@@ -29,5 +29,6 @@ src_prepare() {
 	default
 
 	cabal_chdeps \
-		'QuickCheck           >= 2.8 && < 2.11' 'QuickCheck           >= 2.8'
+		'QuickCheck           >= 2.8 && < 2.11' 'QuickCheck           >= 2.8' \
+		'base                 >= 4.8 && < 4.11' 'base                 >= 4.8'
 }


### PR DESCRIPTION
The upper bound for `base` in this version is 4.12, not 4.11.

Package-Manager: Portage-2.3.40, Repoman-2.3.9