### PR TITLE
profiles/package.mask: unmask blaze-markup and blaze-html

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -54,8 +54,6 @@ dev-haskell/listenbrainz-client
 >=dev-haskell/ansi-terminal-0.7
 >=dev-lang/purescript-0.12.0
 >=dev-haskell/binary-conduit-1.3
->=dev-haskell/blaze-html-0.9
->=dev-haskell/blaze-markup-0.8
 >=dev-haskell/conduit-1.3
 >=dev-haskell/conduit-extra-1.2
 >=dev-haskell/yesod-bin-1.5.2.5


### PR DESCRIPTION
There are a couple of reasons for unmasking these packages.

Firstly, unmasking the newer versions of blaze-markup and
blaze-html does not appear to cause any conflicts. The mask
was originally applied on 6 January 2018 because not enough
packages had been ported to use these newer versions. This
appears to have changed.

I have git grepped the overlay for "<dev-haskell/blaze-markup-0.8"
and "<dev-haskell/blaze-html-0.9". For each grep I checked:
(1) the listed packages for newer versions which depend on
     the masked versions of blaze-markup and blaze-html; and
(2) for conflicts caused by updating to the newer packages which
     rely on the masked versions of blaze-markup and blaze-html.

I accept that manually checking these things is not the most robust
procedure, but from this I determined that there may be no conflicts.

Secondly, the current version of blaze-markup does not build
with ghc 8.4. The masked version does.

If there is more testing that should be done before making a decision
on this pull request I'll make that happen.