### PR TITLE
dev-haskell/language-glsl: fix compatibility with ghc 8.4

### DIFF
--- a/dev-haskell/language-glsl/files/language-glsl-0.2.1-prelude-hiding.patch
+++ b/dev-haskell/language-glsl/files/language-glsl-0.2.1-prelude-hiding.patch
@@ -1,0 +1,24 @@
+From 1d3d66199577a8804d1a6f62c6813401ff7bfc71 Mon Sep 17 00:00:00 2001
+From: Jack Todaro <jackmtodaro@gmail.com>
+Date: Sun, 5 Aug 2018 01:21:54 +1000
+Subject: [PATCH] Language.GLSL.Pretty: import Prelude hiding ( (<>) )
+
+---
+ Language/GLSL/Pretty.hs | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Language/GLSL/Pretty.hs b/Language/GLSL/Pretty.hs
+index b33555a..5cde86e 100644
+--- a/Language/GLSL/Pretty.hs
++++ b/Language/GLSL/Pretty.hs
+@@ -1,6 +1,7 @@
+ {-# OPTIONS_GHC -fno-warn-orphans #-}
+ module Language.GLSL.Pretty where
+ 
++import Prelude hiding ( (<>) )
+ import Text.PrettyPrint.HughesPJClass
+ import Text.Printf
+ 
+-- 
+2.18.0
+

--- a/dev-haskell/language-glsl/language-glsl-0.2.1-r1.ebuild
+++ b/dev-haskell/language-glsl/language-glsl-0.2.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -27,3 +27,5 @@ DEPEND="${RDEPEND}
 		dev-haskell/test-framework
 		dev-haskell/test-framework-hunit )
 "
+
+PATCHES=( "${FILESDIR}"/${P}-prelude-hiding.patch )


### PR DESCRIPTION
Apply patch which hides Prelude.(<>) to solve ambiguity in Pretty.hs.

Package-Manager: Portage-2.3.44, Repoman-2.3.10