### PR TITLE
profiles/package.mask: unmask >=dev-haskell/config-ini-0.2

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -85,7 +85,6 @@ dev-haskell/servant-client-core
 >=dev-haskell/aws-0.19-r1
 >=dev-haskell/classy-prelude-1.4.0
 >=dev-haskell/classy-prelude-conduit-1.4.0
->=dev-haskell/config-ini-0.2
 >=dev-haskell/esqueleto-2.6.0_pre20180402
 >=dev-haskell/fb-1.2.0
 >=dev-haskell/hlint-2.1.0


### PR DESCRIPTION
`config-ini-0.2.2` is only compatible with `megaparsec-6`, which has just been unmasked in the overlay. Unmask `>=dev-haskell/config-ini-0.2` to fix compatibility with `megaparsec-6`.

To the best of my knowledge there are no reverse dependencies conflicting with this unmask.