### PR TITLE
dev-haskell/concurrent-extra: restrict test

### DIFF
--- a/dev-haskell/concurrent-extra/concurrent-extra-0.7.0.12.ebuild
+++ b/dev-haskell/concurrent-extra/concurrent-extra-0.7.0.12.ebuild
@@ -17,6 +17,8 @@ SLOT="0/${PV}"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+RESTRICT=test #stresstest fails, all others pass
+
 RDEPEND=">=dev-haskell/stm-2.1.2.1:=[profile?]
 	>=dev-haskell/unbounded-delays-0.1:=[profile?]
 	>=dev-lang/ghc-7.4.1:=


### PR DESCRIPTION
Test fails on `stresstest`, all other pass. Built with ghc 8.4.

Package-Manager: Portage-2.3.44, Repoman-2.3.10