### PR TITLE
dev-haskell/flac: allow exceptions-0.10

### DIFF
--- a/dev-haskell/flac/flac-0.1.2.ebuild
+++ b/dev-haskell/flac/flac-0.1.2.ebuild
@@ -34,6 +34,13 @@ DEPEND="${RDEPEND}
 		>=dev-haskell/temporary-1.1 <dev-haskell/temporary-1.3 )
 "
 
+src_prepare() {
+	default
+
+	cabal_chdeps \
+		'exceptions       >= 0.6    && < 0.9' 'exceptions       >= 0.6'
+}
+
 src_configure() {
 	haskell-cabal_src_configure \
 		--flag=-dev


### PR DESCRIPTION
RDEPEND allowed exceptions-0.10, but the cabal file did not.

Package-Manager: Portage-2.3.44, Repoman-2.3.10