### PR TITLE
Adjust tagsoup-megaparsec mask

### DIFF
--- a/dev-haskell/tagsoup-megaparsec/tagsoup-megaparsec-0.2.0.0.ebuild
+++ b/dev-haskell/tagsoup-megaparsec/tagsoup-megaparsec-0.2.0.0.ebuild
@@ -15,9 +15,8 @@ SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-# incompatible with >=dev-haskell/megaparsec-6.0, no repo activity since
-# August 2016.
-# KEYWORDS="~amd64 ~x86"
+# incompatible with >=dev-haskell/megaparsec-6.0
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/megaparsec-5.0.1:=[profile?] <dev-haskell/megaparsec-6:=[profile?]

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -1,3 +1,8 @@
+# Jack Todaro <jackmtodaro@gmail.com> (6 Aug 2018)
+# tagsoup-megaparsec is incompatible with megaparsec-6.0
+# https://github.com/gentoo-haskell/gentoo-haskell/pull/762
+dev-haskell/tagsoup-megaparsec
+
 # Sergei Trofimovich <slyfox@gentoo.org> (01 July 2018)
 # Follow ::gentoo's mask of qt:4
 dev-haskell/clocked


### PR DESCRIPTION
tagsoup-megaparsec is now masked in profiles/package.mask. The keywords have been restored in the ebuild.