### PR TITLE
dev-haskell/pandoc-crossref: tighten upper bound on pandoc-types

### DIFF
--- a/dev-haskell/pandoc-crossref/pandoc-crossref-0.2.6.0-r1.ebuild
+++ b/dev-haskell/pandoc-crossref/pandoc-crossref-0.2.6.0-r1.ebuild
@@ -23,7 +23,7 @@ RDEPEND=">=app-text/pandoc-1.19:=[profile?] <app-text/pandoc-1.20:=[profile?]
 	>=dev-haskell/data-accessor-transformers-0.2.1.6:=[profile?] <dev-haskell/data-accessor-transformers-0.3.0.0:=[profile?]
 	>=dev-haskell/data-default-0.4:=[profile?] <dev-haskell/data-default-0.8:=[profile?]
 	>=dev-haskell/mtl-1.1:=[profile?] <dev-haskell/mtl-2.3:=[profile?]
-	>=dev-haskell/pandoc-types-1.17:=[profile?] <dev-haskell/pandoc-types-1.18:=[profile?]
+	>=dev-haskell/pandoc-types-1.17:=[profile?] <dev-haskell/pandoc-types-1.17.5:=[profile?]
 	>=dev-haskell/roman-numerals-0.5:=[profile?] <dev-haskell/roman-numerals-0.6:=[profile?]
 	>=dev-haskell/syb-0.4:=[profile?] <dev-haskell/syb-0.8:=[profile?]
 	>=dev-haskell/utility-ht-0.0.11:=[profile?] <dev-haskell/utility-ht-0.1.0:=[profile?]
@@ -37,3 +37,10 @@ DEPEND="${RDEPEND}
 PATCHES=(
 	"${FILESDIR}"/${P}-new-pandoc-types.patch
 )
+
+src_prepare() {
+	default
+
+	cabal_chdeps \
+		'pandoc-types == 1.17.*' 'pandoc-types >= 1.17 && < 1.17.5'
+}


### PR DESCRIPTION
Note that I couldn't test the build of this on ghc 8.4, since the current version of `pandoc` in the overlay is incompatible.

I assume the problem is the recent bump of `pandoc-types`. Is it enough to tighten the upper bound on `pandoc-types` without putting a hard mask in profiles/package.mask?

Closes: https://github.com/gentoo-haskell/gentoo-haskell/issues/797
Package-Manager: Portage-2.3.45, Repoman-2.3.10