### PR TITLE
dev-haskell/resolv: restrict tests

### DIFF
--- a/dev-haskell/resolv/resolv-0.1.1.1.ebuild
+++ b/dev-haskell/resolv/resolv-0.1.1.1.ebuild
@@ -17,6 +17,8 @@ SLOT="0/${PV}"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+RESTRICT=test # fails to build test suite
+
 RDEPEND=">=dev-haskell/base16-bytestring-0.1:=[profile?] <dev-haskell/base16-bytestring-0.2:=[profile?]
 	>=dev-lang/ghc-7.10.1:=
 "


### PR DESCRIPTION
Fails to build test suite. `dev-haskell/resolv` is required by `=dev-haskell/cabal-install-2.2.0.0`.

Package-Manager: Portage-2.3.46, Repoman-2.3.10

Error message:

Building test suite 'resolv.' for resolv-0.1.1.1..
[1 of 1] Compiling Main             ( src-test/Tests1.hs, dist/build/resolv./resolv.-tmp/Main.dyn_o )

src-test/Tests1.hs:81:53: error:
    • Couldn't match type ‘[Char]’ with ‘Maybe GHC.Stack.Types.SrcLoc’
      Expected type: Maybe GHC.Stack.Types.SrcLoc
        Actual type: String
    • In the first argument of ‘T.HUnitFailure’, namely ‘msg’
      In the first argument of ‘E.throwIO’, namely ‘(T.HUnitFailure msg)’
      In the expression: E.throwIO (T.HUnitFailure msg)
   |
81 | assertJust msg Nothing  = E.throwIO (T.HUnitFailure msg)
   |                                                     ^^^