### PR TITLE
profiles/package.mask: unmask servant-client and dependencies

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -44,6 +44,4 @@ dev-haskell/webkitgtk3-javascriptcore
 # Masked as many reverse dependencies depend on older versions.
 # Most of them need to be ported to newer version.
 >=dev-haskell/aeson-1.3
-dev-haskell/servant-client
 dev-haskell/listenbrainz-client
-dev-haskell/servant-client-core


### PR DESCRIPTION
The masks on `servant-client` and `servant-client-core` are no longer necessary.