### PR TITLE
dev-haskell/cabal: restrict tests

### DIFF
--- a/dev-haskell/cabal/cabal-2.2.0.1.ebuild
+++ b/dev-haskell/cabal/cabal-2.2.0.1.ebuild
@@ -23,27 +23,28 @@ SLOT="0/${PV}"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
+RESTRICT=test # circular dependencies
+
 RDEPEND=">=dev-haskell/mtl-2.1:=[profile?] <dev-haskell/mtl-2.3:=[profile?]
 	>=dev-haskell/parsec-3.1.13.0:=[profile?] <dev-haskell/parsec-3.2:=[profile?]
 	>=dev-haskell/text-1.2.3.0:=[profile?] <dev-haskell/text-1.3:=[profile?]
 	>=dev-lang/ghc-7.8.2:=
 "
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
 
-	 test? ( >=dev-haskell/base-compat-0.9.3
-		>=dev-haskell/base-orphans-0.6
-		>=dev-haskell/diff-0.3.4 <dev-haskell/diff-0.4
-		>=dev-haskell/integer-logarithms-1.0.2 <dev-haskell/integer-logarithms-1.1
-		>=dev-haskell/optparse-applicative-0.13.2.0 <dev-haskell/optparse-applicative-0.15
-		>=dev-haskell/quickcheck-2.11.3 <dev-haskell/quickcheck-2.12
-		dev-haskell/tagged
-		>=dev-haskell/tar-0.5.0.3 <dev-haskell/tar-0.6
-		>=dev-haskell/tasty-1.0
-		>=dev-haskell/tasty-golden-2.3.1.1 <dev-haskell/tasty-golden-2.4
-		dev-haskell/tasty-hunit
-		dev-haskell/tasty-quickcheck
-		>=dev-haskell/tree-diff-0.0.1 <dev-haskell/tree-diff-0.1 )
-"
+	# test? ( >=dev-haskell/base-compat-0.9.3
+	#	>=dev-haskell/base-orphans-0.6
+	#	>=dev-haskell/diff-0.3.4 <dev-haskell/diff-0.4
+	#	>=dev-haskell/integer-logarithms-1.0.2 <dev-haskell/integer-logarithms-1.1
+	#	>=dev-haskell/optparse-applicative-0.13.2.0 <dev-haskell/optparse-applicative-0.15
+	#	>=dev-haskell/quickcheck-2.11.3 <dev-haskell/quickcheck-2.12
+	#	dev-haskell/tagged
+	#	>=dev-haskell/tar-0.5.0.3 <dev-haskell/tar-0.6
+	#	>=dev-haskell/tasty-1.0
+	#	>=dev-haskell/tasty-golden-2.3.1.1 <dev-haskell/tasty-golden-2.4
+	#	dev-haskell/tasty-hunit
+	#	dev-haskell/tasty-quickcheck
+	#	>=dev-haskell/tree-diff-0.0.1 <dev-haskell/tree-diff-0.1 )
 
 CABAL_CORE_LIB_GHC_PV="PM:8.4.2_rc1 PM:8.4.2 PM:8.4.3"
 


### PR DESCRIPTION
Avoid circular dependencies when upgrading.

Bug: https://github.com/gentoo-haskell/gentoo-haskell/issues/810
Package-Manager: Portage-2.3.47, Repoman-2.3.10