### PR TITLE
Fix ci failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 python:
     - pypy
 env:
-    - PORTAGE_VER="2.3.43"
+    - PORTAGE_VER="2.3.47"
 before_install:
     - sudo apt-get -qq update
     - pip install lxml pyyaml

--- a/dev-haskell/ansi-terminal/ansi-terminal-0.8.0.4.ebuild
+++ b/dev-haskell/ansi-terminal/ansi-terminal-0.8.0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+KEYWORDS="~amd64 ~x86"
 IUSE="example"
 
 RDEPEND="dev-haskell/colour:=[profile?]

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -37,4 +37,3 @@ dev-haskell/webkitgtk3-javascriptcore
 # Most of them need to be ported to newer version.
 >=dev-haskell/aeson-1.3
 dev-haskell/listenbrainz-client
-dev-haskell/skylighting-core


### PR DESCRIPTION
* Unmask `dev-haskell/skylighting-core` for `dev-haskell/skylighting-0.7.2`
* Drop all keywords except for `amd64` and `x86` in `dev-haskell/ansi-terminal-0.8.0.4` since the dependency `dev-haskell/colour` does not exist on other arches.