### PR TITLE
dev-haskell/hsyaml: Update dlist dep

### DIFF
--- a/dev-haskell/hsyaml/hsyaml-0.1.1.2.ebuild
+++ b/dev-haskell/hsyaml/hsyaml-0.1.1.2.ebuild
@@ -20,7 +20,7 @@ SLOT="0/${PV}"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-RDEPEND=">=dev-haskell/dlist-0.8:=[profile?] <dev-haskell/dlist-0.9:=[profile?]
+RDEPEND=">=dev-haskell/dlist-0.8.0.4:=[profile?] <dev-haskell/dlist-0.9:=[profile?]
 	>=dev-haskell/fail-4.9.0.0:=[profile?] <dev-haskell/fail-4.10:=[profile?]
 	>=dev-haskell/mtl-2.2.1:=[profile?] <dev-haskell/mtl-2.3:=[profile?]
 	>=dev-haskell/nats-1.1.2:=[profile?] <dev-haskell/nats-1.2:=[profile?]


### PR DESCRIPTION
Trying to install with dlist-0.8.0.2 produces the following error. Succeeds with 0.8.0.4.
```
Preprocessing library for HsYAML-0.1.1.2..
Building library for HsYAML-0.1.1.2..
[1 of 7] Compiling Util             ( src/Util.hs, dist/build/Util.o )
[2 of 7] Compiling Data.YAML.Token.Encoding ( src/Data/YAML/Token/Encoding.hs, dist/build/Data/YAML/Token/Encoding.o )
[3 of 7] Compiling Data.YAML.Token  ( src/Data/YAML/Token.hs, dist/build/Data/YAML/Token.o )

src/Data/YAML/Token.hs:28:1: error:
    Data.DList: Can't be safely imported! The module itself isn't safe.
```