### PR TITLE
dev-haskell/deriving-compat: allow template-haskell 2.13

### DIFF
--- a/dev-haskell/deriving-compat/deriving-compat-0.3.6.ebuild
+++ b/dev-haskell/deriving-compat/deriving-compat-0.3.6.ebuild
@@ -17,6 +17,8 @@ SLOT="0/${PV}"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+RESTRICT=test # tests fail to build
+
 RDEPEND=">=dev-haskell/transformers-compat-0.5:=[profile?]
 	>=dev-lang/ghc-7.8.2:=
 "
@@ -33,5 +35,6 @@ src_prepare() {
 	default
 
 	cabal_chdeps \
-		'template-haskell    >= 2.11 && < 2.13' 'template-haskell    >= 2.11'
+		'template-haskell    >= 2.11 && < 2.13' 'template-haskell    >= 2.11' \
+		'template-haskell    >= 2.5   && < 2.13' 'template-haskell    >= 2.5'
 }


### PR DESCRIPTION
Tests fail to compile and have been disabled.

Package-Manager: Portage-2.3.48, Repoman-2.3.10