### PR TITLE
dev-haskell/http: Allow base-4.12

### DIFF
--- a/dev-haskell/http/http-4000.3.12.ebuild
+++ b/dev-haskell/http/http-4000.3.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -38,6 +38,13 @@ DEPEND="${RDEPEND}
 "
 
 S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	default
+
+	cabal_chdeps \
+		'base >= 4.3.0.0 && < 4.12' 'base >= 4.3.0.0 && < 4.13'
+}
 
 src_configure() {
 	haskell-cabal_src_configure \


### PR DESCRIPTION
https://hackage.haskell.org/package/HTTP-4000.3.12/revisions/

Signed-off-by: Harri Nieminen <moikkis@gmail.com>
Package-Manager: Portage-2.3.49, Repoman-2.3.11