### PR TITLE
x11-misc/xmobar: Allow base-4.13 and stm-2.5

### DIFF
--- a/x11-misc/xmobar/xmobar-0.28.ebuild
+++ b/x11-misc/xmobar/xmobar-0.28.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -23,7 +23,7 @@ RDEPEND=">=dev-haskell/mtl-2.1:= <dev-haskell/mtl-2.3:=
 	>=dev-haskell/parsec-3.1:= <dev-haskell/parsec-3.2:=
 	>=dev-haskell/parsec-numbers-0.1.0:=
 	dev-haskell/regex-compat:=
-	>=dev-haskell/stm-2.3:= <dev-haskell/stm-2.5:=
+	>=dev-haskell/stm-2.3:= <dev-haskell/stm-2.6:=
 	>=dev-haskell/utf8-string-0.3:= <dev-haskell/utf8-string-1.1:=
 	>=dev-haskell/x11-1.6.1:=
 	>=dev-lang/ghc-8.0.2:=
@@ -57,6 +57,14 @@ DEPEND="${RDEPEND}
 	test? ( >=dev-haskell/hspec-2 <dev-haskell/hspec-3
 		~dev-haskell/parsec-numbers-0.1.0 )
 "
+
+src_prepare() {
+	default
+
+	cabal_chdeps \
+		'base >= 4.9.1.0 && < 4.12' 'base >= 4.9.1.0 && < 4.13' \
+		'stm >= 2.3 && < 2.5' 'stm >= 2.3 && < 2.6'
+}
 
 src_configure() {
 	haskell-cabal_src_configure \


### PR DESCRIPTION
https://github.com/jaor/xmobar/commit/5c571e757718f41889d45406529bc39e10baf55c

Signed-off-by: Harri Nieminen <moikkis@gmail.com>
Package-Manager: Portage-2.3.50, Repoman-2.3.11