### PR TITLE
dev-haskell/beam-core: Bump to 0.7.2.2-r1

### DIFF
--- a/dev-haskell/beam-core/beam-core-0.7.2.2-r1.ebuild
+++ b/dev-haskell/beam-core/beam-core-0.7.2.2-r1.ebuild
@@ -35,11 +35,8 @@ DEPEND="${RDEPEND}
 		dev-haskell/tasty-hunit )
 "
 
-# I don't see the need to include this build flag
-
-# IUSE="werror"
-
-#src_configure() {
-#	haskell-cabal_src_configure \
-#		$(cabal_flag werror werror)
-#}
+src_prepare() {
+	default
+	cabal_chdeps \
+		'free         >=4.12    && <5.1' 'free >= 4.12 && <5.2'
+}

--- a/dev-haskell/beam-migrate/beam-migrate-0.3.2.1-r1.ebuild
+++ b/dev-haskell/beam-migrate/beam-migrate-0.3.2.1-r1.ebuild
@@ -38,9 +38,8 @@ DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-1.24.0.0
 "
 
-# I don't see a need for this build flag
-#IUSE="werror"
-#src_configure() {
-#	haskell-cabal_src_configure \
-#		$(cabal_flag werror werror)
-#}
+src_prepare() {
+	default
+	cabal_chdeps \
+		'free                 >=4.12    && <5.1' 'free >= 4.12 && <5.2'
+}

--- a/dev-haskell/beam-postgres/beam-postgres-0.3.2.2-r1.ebuild
+++ b/dev-haskell/beam-postgres/beam-postgres-0.3.2.2-r1.ebuild
@@ -22,7 +22,7 @@ RDEPEND=">=dev-haskell/aeson-0.11:=[profile?] <dev-haskell/aeson-1.5:=[profile?]
 	>=dev-haskell/beam-migrate-0.3:=[profile?] <dev-haskell/beam-migrate-0.4:=[profile?]
 	>=dev-haskell/case-insensitive-1.2:=[profile?] <dev-haskell/case-insensitive-1.3:=[profile?]
 	>=dev-haskell/conduit-1.2:=[profile?] <dev-haskell/conduit-1.4:=[profile?]
-	>=dev-haskell/free-4.12:=[profile?] <dev-haskell/free-5.1:=[profile?]
+	>=dev-haskell/free-4.12:=[profile?] <dev-haskell/free-5.2:=[profile?]
 	>=dev-haskell/hashable-1.1:=[profile?] <dev-haskell/hashable-1.3:=[profile?]
 	>=dev-haskell/haskell-src-exts-1.18:=[profile?] <dev-haskell/haskell-src-exts-1.21:=[profile?]
 	>=dev-haskell/lifted-base-0.2:=[profile?] <dev-haskell/lifted-base-0.3:=[profile?]
@@ -43,9 +43,8 @@ DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-1.24.0.0
 "
 
-# I don't see a need for this build flag
-# IUSE="werror"
-#src_configure() {
-#	haskell-cabal_src_configure \
-#		$(cabal_flag werror werror)
-#}
+src_prepare() {
+	default
+	cabal_chdeps \
+		'free                 >=4.12 && <5.1' 'free >=4.12 && <5.2'
+}


### PR DESCRIPTION
`beam-core` has been revised upstream to no longer allow `free >= 5.1`

This updates the ebuild and adds the latest version of `free` which meets this new constraint.