### PR TITLE
eclass: update eclasses for EAPI 7

### DIFF
--- a/eclass/darcs.eclass
+++ b/eclass/darcs.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: darcs.eclass
@@ -21,7 +21,12 @@
 
 # support for tags
 
-inherit eutils # eshopts_{push,pop}
+# eshopts_{push,pop}
+case "${EAPI:-0}" in
+	4|5|6) inherit eutils ;;
+	7)     inherit estack ;;
+	*) ;;
+esac
 
 # Don't download anything other than the darcs repository
 SRC_URI=""

--- a/eclass/ghc-package.eclass
+++ b/eclass/ghc-package.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: ghc-package.eclass
@@ -10,7 +10,15 @@
 # @DESCRIPTION:
 # Helper eclass to handle ghc installation/upgrade/deinstallation process.
 
-inherit multiprocessing versionator
+inherit multiprocessing
+
+# Maintain version-testing compatibility with ebuilds not using EAPI 7.
+# The overlay does not contain any ebuilds lower than EAPI 4, so we don't
+# test for that.
+case "${EAPI:-0}" in
+	4|5|6) inherit eapi7-ver ;;
+	*) ;;
+esac
 
 # @FUNCTION: ghc-getghc
 # @DESCRIPTION:
@@ -35,7 +43,7 @@ ghc-getghcpkg() {
 # because for some reason the global package file
 # must be specified
 ghc-getghcpkgbin() {
-	if version_is_at_least "7.9.20141222" "$(ghc-version)"; then
+	if ver_test "$(ghc-version)" -ge "7.9.20141222"; then
 		# ghc-7.10 stopped supporting single-file database
 		local empty_db="${T}/empty.conf.d" ghc_pkg="$(ghc-libdir)/bin/ghc-pkg"
 		if [[ ! -d ${empty_db} ]]; then
@@ -43,7 +51,7 @@ ghc-getghcpkgbin() {
 		fi
 		echo "$(ghc-libdir)/bin/ghc-pkg" "--global-package-db=${empty_db}"
 
-	elif version_is_at_least "7.7.20121101" "$(ghc-version)"; then
+	elif ver_test "$(ghc-version)" -ge "7.7.20121101"; then
 		# the ghc-pkg executable changed name in ghc 6.10, as it no longer needs
 		# the wrapper script with the static flags
 		# was moved to bin/ subtree by:
@@ -51,7 +59,7 @@ ghc-getghcpkgbin() {
 		echo '[]' > "${T}/empty.conf"
 		echo "$(ghc-libdir)/bin/ghc-pkg" "--global-package-db=${T}/empty.conf"
 
-	elif version_is_at_least "7.5.20120516" "$(ghc-version)"; then
+	elif ver_test "$(ghc-version)" -ge "7.5.20120516"; then
 		echo '[]' > "${T}/empty.conf"
 		echo "$(ghc-libdir)/ghc-pkg" "--global-package-db=${T}/empty.conf"
 
@@ -94,7 +102,7 @@ ghc-pm-version() {
 # @DESCRIPTION:
 # return version of the Cabal library bundled with ghc
 ghc-cabal-version() {
-	if version_is_at_least "7.9.20141222" "$(ghc-version)"; then
+	if ver_test "$(ghc-version)" -ge "7.9.20141222"; then
 		# outputs in format: 'version: 1.18.1.5'
 		set -- `$(ghc-getghcpkg) --package-db=$(ghc-libdir)/package.conf.d.initial field Cabal version`
 		echo "$2"

--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: haskell-cabal.eclass
@@ -82,7 +82,7 @@ HASKELL_CABAL_EXPF="pkg_setup src_compile src_test src_install pkg_postinst pkg_
 QA_CONFIGURE_OPTIONS+=" --with-compiler --with-hc --with-hc-pkg --with-gcc"
 
 case "${EAPI:-0}" in
-	2|3|4|5|6) HASKELL_CABAL_EXPF+=" src_configure" ;;
+	2|3|4|5|6|7) HASKELL_CABAL_EXPF+=" src_configure" ;;
 	*) ;;
 esac
 
@@ -375,7 +375,7 @@ cabal-configure() {
 	if $(ghc-supports-shared-libraries); then
 		# Experimental support for dynamically linked binaries.
 		# We are enabling it since 7.10.1_rc3
-		if version_is_at_least "7.10.0.20150316" "$(ghc-version)"; then
+		if ver_test "$(ghc-version)" -ge "7.10.0.20150316"; then
 			# we didn't enable it before as it was not stable on all arches
 			cabalconf+=(--enable-shared)
 			# Known to break on ghc-7.8/Cabal-1.18


### PR DESCRIPTION
I've opened this PR for discussion and review, given the changes touch the eclasses.

`darcs.eclass`, `ghc-package.eclass` and `haskell-cabal.eclass` have been updated to be compatible with ebuilds using EAPI 7, with the intention of maintaining compatibility with earlier EAPIs.

The main change is eliminating `versionator` from `ghc-package.eclass`, and replacing `version_is_at_least` with `ver_test` from either `eapi7-ver.eclass` for ebuilds not yet using EAPI 7, or the built-in `ver-test` for ebuilds using EAPI 7.

One issue with this is that it seems that `eapi7-ver.eclass` doesn't appear to be intended for general use, but rather for testing EAPI 7's new versioning functions before they were formally released. Nevertheless it appears to work.

Bug: https://github.com/gentoo-haskell/hackport/issues/42
Signed-off-by: Jack Todaro <jackmtodaro@gmail.com>