### PR TITLE
use package.mask for new ghc releases plz

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -1,3 +1,15 @@
+# Masked due to widespread breakages and lack of binaries
+# to build dev-lang/ghc w/o USE=ghcbootstrap
+# See HOWTO-keyword-ghc.rst
+# ghc-8.6.3
+=dev-lang/ghc-8.6.3
+=dev-haskell/cabal-2.4.0.1
+=dev-haskell/cabal-install-2.4.0.0
+=dev-haskell/stm-2.5.0.0
+=dev-haskell/haddock-library-1.7.0
+=dev-haskell/terminfo-0.4.1.2
+=dev-haskell/haskeline-0.7.4.3
+
 # Jack Todaro <jackmtodaro@gmail.com> (21 December 2018)
 # ghc-syb-utils-0.2 is incompatible with ghc-8.4, but is
 # required by ghc-mod which is currently masked for the


### PR DESCRIPTION
so it would be easier to unmask it both locally and globally