### PR TITLE
dev-haskell/blaze-html: Fix typo in ebuild

### DIFF
--- a/dev-haskell/blaze-html/blaze-html-0.9.1.1.ebuild
+++ b/dev-haskell/blaze-html/blaze-html-0.9.1.1.ebuild
@@ -35,6 +35,6 @@ src_prepare() {
 	default
 
 	cabal_chdeps \
-		'QuickCheck                 >= 2.4 && < 2.12' 'QuickCheck                 >= 2.4'
+		'QuickCheck                 >= 2.4 && < 2.12' 'QuickCheck                 >= 2.4'\
 		'containers                 >= 0.3 && < 0.6' 'containers                 >= 0.3'
 }


### PR DESCRIPTION
This prevents the package from being built against the ghc-8.6.3 environment