### PR TITLE
Mask USE flags for various packages

### DIFF
--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -24,3 +24,8 @@ app-editors/leksah codemirror
 dev-haskell/servant test
 dev-haskell/lens-aeson test
 dev-haskell/linear test
+
+# hololeap <hololeap@gmail.com> (05 Apr 2019)
+# Tests fail for unknown reasons
+dev-haskell/alex test
+

--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -18,3 +18,7 @@ app-editors/leksah codemirror
 <=dev-haskell/gnuidn-0.2.2 test
 <=dev-haskell/system-filepath-0.4.14 test
 <=dev-haskell/dbus-0.10.13 test
+
+# hololeap <hololeap@gmail.com> (05 Apr 2019)
+# Tests that use doctests are currently failing to execute
+dev-haskell/servant test

--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -28,4 +28,4 @@ dev-haskell/linear test
 # hololeap <hololeap@gmail.com> (05 Apr 2019)
 # Tests fail for unknown reasons
 dev-haskell/alex test
-
+dev-haskell/singletons test

--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -29,3 +29,7 @@ dev-haskell/linear test
 # Tests fail for unknown reasons
 dev-haskell/alex test
 dev-haskell/singletons test
+
+# hololeap <hololeap@gmail.com> (05 Apr 2019)
+# Docs fail to build for unknown reasons
+dev-haskell/haddock-api doc

--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -22,3 +22,4 @@ app-editors/leksah codemirror
 # hololeap <hololeap@gmail.com> (05 Apr 2019)
 # Tests that use doctests are currently failing to execute
 dev-haskell/servant test
+dev-haskell/lens-aeson test

--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -23,3 +23,4 @@ app-editors/leksah codemirror
 # Tests that use doctests are currently failing to execute
 dev-haskell/servant test
 dev-haskell/lens-aeson test
+dev-haskell/linear test


### PR DESCRIPTION
I am unable to compile some packages if certain USE flags are enabled. It makes sense to mask those USE flags on the packages.