### PR TITLE
dev-haskell/encoding tweak for ghc-8.6.5

### DIFF
--- a/dev-haskell/encoding/encoding-0.8.2.ebuild
+++ b/dev-haskell/encoding/encoding-0.8.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -31,6 +31,7 @@ DEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${P}-cabal22.patch
+	"${FILESDIR}"/${P}-ghc-865.patch
 )
 
 src_prepare() {

--- a/dev-haskell/encoding/files/encoding-0.8.2-ghc-865.patch
+++ b/dev-haskell/encoding/files/encoding-0.8.2-ghc-865.patch
@@ -1,0 +1,13 @@
+diff --git a/encoding.cabal b/encoding.cabal
+index ec20617..a1efe27 100644
+--- a/encoding.cabal
++++ b/encoding.cabal
+@@ -47,7 +47,7 @@ Library
+                  base >=4 && <5,
+                  binary >=0.7 && <0.10,
+                  bytestring >=0.9 && <0.11,
+-                 containers >=0.4 && <0.6,
++                 containers >=0.4 && <0.7,
+                  extensible-exceptions >=0.1 && <0.2,
+                  ghc-prim >=0.3 && <0.6,
+                  mtl >=2.0 && <2.3,


### PR DESCRIPTION
Library seems to be abandoned but still fully compatible with containers-0.6+

Tested on ghc-8.6.4