### PR TITLE
yesod-bin-1.6.0.3 broken dependency

### DIFF
--- a/dev-haskell/yesod-bin/yesod-bin-1.6.0.3-r2.ebuild
+++ b/dev-haskell/yesod-bin/yesod-bin-1.6.0.3-r2.ebuild
@@ -62,5 +62,6 @@ src_prepare() {
 	default
 
 	cabal_chdeps \
-		'yaml               >= 0.8          && < 0.9' 'yaml               >= 0.8'
+		'yaml               >= 0.8          && < 0.9' 'yaml               >= 0.8' \
+		'fsnotify           >= 0.0          && < 0.3' 'fsnotify           >= 0.0          && < 0.4'
 }


### PR DESCRIPTION
yesod-bin-1.6.0.3 in hackage mistakenly restricts fsnotify to '< 0.3'. Both the hackage description itself and the upstream repo on github specify < 0.4.