### PR TITLE
Elm-compiler: Added dependency on haskell package 'containers'

### DIFF
--- a/dev-lang/elm-compiler/elm-compiler-0.19.0-r1.ebuild
+++ b/dev-lang/elm-compiler/elm-compiler-0.19.0-r1.ebuild
@@ -54,7 +54,7 @@ src_prepare() {
 	default
 
 	CABAL_FILE=elm.cabal cabal_chdeps \
-		'language-glsl >= 0.0.2 && < 0.3' 'language-glsl >= 0.0.2'
+		'language-glsl >= 0.0.2 && < 0.3' 'language-glsl >= 0.0.2' 'containers >= 0.5.8.2 && < 0.6' 'containers >= 0.5.8.2'
 }
 
 src_configure() {


### PR DESCRIPTION
Found out the dependency on the haskell package containers was missing. Added the appropriate version as dependency to ebuild.

Feedback is greatly appreciated since this is my first contribution around here :)