### PR TITLE
dev-vcs/git-annex: support >=socks-0.6

### DIFF
--- a/dev-vcs/git-annex/files/git-annex-7.20190129-socks-0.6.patch
+++ b/dev-vcs/git-annex/files/git-annex-7.20190129-socks-0.6.patch
@@ -1,0 +1,27 @@
+From 018b5b81736a321f3eb9762a2afb7124e19dbdf9 Mon Sep 17 00:00:00 2001
+
+diff --git a/Utility/Tor.hs b/Utility/Tor.hs
+index 427fb100b..094c91aac 100644
+--- a/Utility/Tor.hs
++++ b/Utility/Tor.hs
+@@ -5,6 +5,8 @@
+  - Licensed under the GNU AGPL version 3 or higher.
+  -}
+ 
++{-# LANGUAGE CPP #-}
++
+ module Utility.Tor where
+ 
+ import Common
+@@ -37,7 +39,12 @@ connectHiddenService (OnionAddress address) port = do
+ 	return s
+   where
+ 	torsocksport = 9050
++#if MIN_VERSION_socks(0,6,0)
++	torsockconf = defaultSocksConf $ SockAddrInet torsocksport $
++		tupleToHostAddress (127,0,0,1)
++#else
+ 	torsockconf = defaultSocksConf "127.0.0.1" torsocksport
++#endif
+ 	socksdomain = SocksAddrDomainName (BU8.fromString address)
+ 	socksaddr = SocksAddress socksdomain (fromIntegral port)

--- a/dev-vcs/git-annex/git-annex-7.20190129.ebuild
+++ b/dev-vcs/git-annex/git-annex-7.20190129.ebuild
@@ -119,6 +119,7 @@ DEPEND="${DEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-6.20170101-crypto-api.patch
+	"${FILESDIR}"/${PN}-7.20190129-socks-0.6.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Pull changes from `git-annex` upstream [094c91aacd24cff5394fed74a64bbbba77b7498b](http://source.git-annex.branchable.com/?p=source.git;a=blobdiff;f=Utility/Tor.hs;h=094c91aacd24cff5394fed74a64bbbba77b7498b;hp=427fb100bc222ac58c4fd61059e02f606749f377;hb=018b5b81736a321f3eb9762a2afb7124e19dbdf9;hpb=9fd37e65d05c6169a81d066658776e0dc19e9495) as a patch to support `>=dev-haskell/socks-0.6`.