### PR TITLE
dev-haskell/mustache rudimentary 'either' dep. drop

### DIFF
--- a/dev-haskell/mustache/files/mustache-2.3.1-r1-either.patch
+++ b/dev-haskell/mustache/files/mustache-2.3.1-r1-either.patch
@@ -1,0 +1,12 @@
+diff --git a/mustache.cabal b/mustache.cabal
+index 5763035..c5c2e8f 100644
+--- a/mustache.cabal
++++ b/mustache.cabal
+@@ -48,7 +48,6 @@ library
+     , bytestring
+     , containers
+     , directory
+-    , either
+     , filepath
+     , mtl >=2.2.1
+     , parsec

--- a/dev-haskell/mustache/mustache-2.3.1-r1.ebuild
+++ b/dev-haskell/mustache/mustache-2.3.1-r1.ebuild
@@ -21,7 +21,6 @@ RESTRICT=test # tries to access network
 
 RDEPEND="dev-haskell/aeson:=[profile?]
 	dev-haskell/cmdargs:=[profile?]
-	dev-haskell/either:=[profile?]
 	>=dev-haskell/mtl-2.2.1:=[profile?]
 	dev-haskell/parsec:=[profile?]
 	dev-haskell/scientific:=[profile?]
@@ -42,3 +41,7 @@ DEPEND="${RDEPEND}
 		dev-haskell/wreq
 		dev-haskell/zlib )
 "
+
+PATCHES=(
+	"${FILESDIR}"/${PF}-either.patch
+)


### PR DESCRIPTION
_dev-haskell/stack-2.3.3::haskell_ [**->**](https://github.com/gentoo-haskell/gentoo-haskell/blob/master/dev-haskell/stack/stack-2.3.3.ebuild#L59) _dev-haskell/mustache_ [**->**](https://github.com/gentoo-haskell/gentoo-haskell/blob/master/dev-haskell/mustache/mustache-2.3.1.ebuild#L24) [_either_](https://hackage.haskell.org/package/either) which was  [removed](https://github.com/gentoo-haskell/gentoo-haskell/commit/b578b260d8de1c70c590c0e8951a57c5ab57ac8c#diff-a22be0b35f0c09a54e0200743553e8e5c6287a3eb75d321e48bd093c6879e6ac) from ::haskell a while ago causing portage to pull [dev-haskell/either::gentoo](https://packages.gentoo.org/packages/dev-haskell/either) 

Looking up mustache [sources](https://github.com/JustusAdam/mustache) I haven't found any usage of [_dev-haskell/either combinators_](https://hackage.haskell.org/package/either) and was able to compile without it

There could be an ancient _"either monad"_ package at some point merged into GHC but someone took the same _either_ package name on hackage causing tangles for compiling an old packages as well as generating ebuilds with Hackport 
_Tho it's only my guess since that thing looks really confusing_