### PR TITLE
app-portage/hackport-9999 added missing dependency.

### DIFF
--- a/app-portage/hackport/hackport-9999.ebuild
+++ b/app-portage/hackport/hackport-9999.ebuild
@@ -34,6 +34,7 @@ RDEPEND="app-portage/repoman
 	>=dev-haskell/network-uri-2.6:=
 	>=dev-haskell/old-locale-1.0:=
 	>=dev-haskell/parsec-3.1.13:=
+	>=dev-haskell/parallel-3.2.1.0:=
 	>=dev-haskell/random-1.0:=
 	dev-haskell/split:=
 	>=dev-haskell/stm-2.0:=


### PR DESCRIPTION
Signed-off-by: Wolfgang E. Sanyer <WolfgangESanyer@gmail.com>