### PR TITLE
profiles/package.mask: move glirc to aeson-1.5 section, unmask config…

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -95,14 +95,6 @@ dev-haskell/unbound
 dev-haskell/console-program
 
 # Sergei Trofimovich <slyfox@gentoo.org> (2020-12-22)
-# Some packages still need older versions: https://github.com/gentoo-haskell/gentoo-haskell/issues/1105
->=dev-haskell/config-value-0.8
->=dev-haskell/config-schema-1.2.1.0
->=dev-haskell/glirc-2.37
->=dev-haskell/hookup-0.5
->=dev-haskell/irc-core-2.9
-
-# Sergei Trofimovich <slyfox@gentoo.org> (2020-12-22)
 # Needs update to optparse-applciative and newer containers: https://github.com/MichaelXavier/Angel/issues/52
 dev-haskell/angel
 
@@ -333,6 +325,7 @@ sci-mathematics/agda-lib-ffi
 >=dev-haskell/th-abstraction-0.4
 >=dev-haskell/these-1.1
 >=dev-haskell/quickcheck-instances-0.3.23
+>=dev-haskell/glirc-2.37 # also requires older config-value and config-schema
 
 # Jack Todaro <solpeth@posteo.org> (2020-08-12)
 # Many packages require QuickCheck < 2.14. Mask


### PR DESCRIPTION
…-schema

Signed-off-by: Wolfgang E. Sanyer <WolfgangESanyer@gmail.com>

I can confirm that all unmasked packages compile and test-suites pass in a clean build environment.

Closes #1105