### PR TITLE
[draft] dev-haskell/mysql: bump to 0.1.7.2-r1, add missing dev-db/mysql dep

### DIFF
--- a/dev-haskell/mysql/mysql-0.1.7.2-r1.ebuild
+++ b/dev-haskell/mysql/mysql-0.1.7.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,7 +20,8 @@ IUSE=""
 
 RESTRICT=test # needs local mysql
 
-RDEPEND=">=dev-haskell/semigroups-0.11:=[profile?] <dev-haskell/semigroups-0.19:=[profile?]
+RDEPEND="dev-db/mysql:=
+	>=dev-haskell/semigroups-0.11:=[profile?] <dev-haskell/semigroups-0.19:=[profile?]
 	>=dev-lang/ghc-7.4.1:=
 "
 DEPEND="${RDEPEND}

--- a/dev-haskell/mysql/mysql-0.1.7.2-r1.ebuild
+++ b/dev-haskell/mysql/mysql-0.1.7.2-r1.ebuild
@@ -20,7 +20,7 @@ IUSE=""
 
 RESTRICT=test # needs local mysql
 
-RDEPEND="dev-db/mysql:=
+RDEPEND="dev-db/mysql-connector-c:=
 	>=dev-haskell/semigroups-0.11:=[profile?] <dev-haskell/semigroups-0.19:=[profile?]
 	>=dev-lang/ghc-7.4.1:=
 "

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -1,13 +1,3 @@
-# Wolfgang E. Sanyer <WolfgangESanyer@gmail.com> (2021-01-13)
-# As discussed in #1127, dev-haskell/mysql does not merge due to a missing
-# dependency. PR #1128 attempts to resolve this issue. Until this PR is merged,
-# mysql and its revdeps will be masked
->=dev-haskell/mysql-0.1.7.2
->=dev-haskell/esqueleto-3.3.4.0
->=dev-haskell/persistent-mysql-2.10.2.3
->=dev-haskell/persistent-relational-record-0.3.0
->=dev-haskell/mysql-simple-0.4.5
-
 # Wolfgang E. Sanyer <WolfgangESanyer@gmail.com> (2021-01-04)
 # This package is not currently maintained, and does not work with the latest
 # version of dev-haskell/github https://github-backup.branchable.com/todo/new_maintainer_needed/


### PR DESCRIPTION
Signed-off-by: Wolfgang E. Sanyer <WolfgangESanyer@gmail.com>

This should close #1127.

I'm unsure whether the `dev-db/mysql` dependency is truly a runtime dependency
or strictly a build-time dependency.

Per #1127, it is obviously needed during build-time, however I don't see any
dependency information in upstream's documentation that explicitly states this
is a dependency.

Rather, there [is acknowledgement][1] in the cabal file that the package links
against an external library, but again I'm unclear whether `dev-db/mysql`
satisfies this requirement or whether something else is needed.

However, I can confirm that this change allows `dev-haskell/mysql` to be merged
succesfully

[1]: https://github.com/paul-rouse/mysql/blob/master/mysql.cabal#L14
