### PR TITLE
profiles/package.mask: Remove haskell-src-exts masks

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -384,12 +384,6 @@ sci-mathematics/agda-lib-ffi
 # Needs porting to Cabal-3
 dev-lang/purescript
 
-# Jack Todaro <solpeth@posteo.org> (12 April 2020)
-# Mask haskell-src-exts-1.22 and reverse dependencies
->=dev-haskell/haskell-src-exts-1.22
->=dev-haskell/haskell-src-exts-simple-1.22
->=dev-haskell/hoogle-5.0.17.12
-
 # Jack Todaro <solpeth@posteo.org> (10 Apr 2020)
 # Mask >=dev-haskell/network-3.1 due to reverse dependency
 # breakages (e.g. purescript)


### PR DESCRIPTION
I _think_ this would close #1043 . It seems to cause no issues on my system. What else is needed?