### PR TITLE
Add GitHub workflow for pkgcheck CI

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -1,0 +1,45 @@
+name: pkgcheck
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      # force all history to be pulled for git-related checks
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Configure pkgcheck cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pkgcheck
+          ~/.cache/pkgcore
+        key: pkgcheck # static value to force cache pull
+
+    - name: Install pkgcheck
+      run: |
+        pip install --upgrade pip
+        pip install pkgcheck
+    - name: Sync gentoo repo
+      run: sudo env "PATH=$PATH" pmaint sync gentoo
+
+    - name: Regen repo metadata
+      run: sudo env "PATH=$PATH" pmaint regen --dir ~/.cache/pkgcheck/repos .
+
+    - name: Run pkgcheck
+      # NonSolvableDepsInXXX is a false positive. This is fixed in
+      # https://github.com/pkgcore/pkgcheck/issues/281 , and we can remove this
+      # keyword flag once the next pkgcheck release hits
+      run: sudo env "PATH=$PATH" pkgcheck --color y scan --exit --checks=-RedundantVersionCheck --keywords=-NonsolvableDepsInDev,-NonsolvableDepsInStable,-NonsolvableDepsInExp

--- a/.github/workflows/repoman.yml
+++ b/.github/workflows/repoman.yml
@@ -1,0 +1,34 @@
+name: repoman
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Setup repoman
+      run: |
+        python -m pip install --upgrade pip
+        pip install lxml pyyaml
+        wget -qO - "https://github.com/gentoo/portage/archive/portage-3.0.12.tar.gz" | tar xz
+        sudo groupadd -g 250 portage
+        sudo useradd -g portage -d /var/tmp/portage -s /bin/false -u 250 portage
+    - name: Setup master gentoo repository
+      run: |
+        sudo mkdir -p /var/db/repos/gentoo /etc/portage /var/cache/distfiles
+        wget -qO - "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" | sudo tar xz -C /var/db/repos/gentoo --strip-components=1
+        sudo wget "https://www.gentoo.org/dtd/metadata.dtd" -O /var/cache/distfiles/metadata.dtd
+        sudo wget "https://gitweb.gentoo.org/proj/portage.git/plain/cnf/repos.conf" -O /etc/portage/repos.conf
+        sudo ln -s /var/db/repos/gentoo/profiles/default/linux/amd64/17.0 /etc/portage/make.profile
+    - name: Test with repoman
+      run: |
+        python3 portage-portage-3.0.12/repoman/bin/repoman full -dx


### PR DESCRIPTION
This PR will actually require a tweak after merge in order to fix the badge on the `README` - it currently links to my forked repo, but I don't really know what the link in the haskell repo will be until we add the github actions setup.

Below is a screenshot of how the badge will look once it is setup.

I'm interested in transitioning **away** from travis-ci **towards** github actions (I can add an action for repoman as well) since it is supported natively and seems to be a tad faster.

I'm also interested in updating this to, say, only run `pkgcheck scan --commits` when a PR is submitted, and also add checks to **not** run CI if certain keywords are present in the commit message. I think this should all be rather trivial to implement since it is all native to github.

![image](https://user-images.githubusercontent.com/573684/107697252-fd868f80-6c80-11eb-9faa-737e1127aec4.png)
