### PR TITLE
dev-haskell/cabal-3.2.1.0-r1: fix CABAL_CORE_LIB_GHC_PV for rev-bumped ghc

### DIFF
--- a/dev-haskell/cabal/cabal-3.2.1.0-r1.ebuild
+++ b/dev-haskell/cabal/cabal-3.2.1.0-r1.ebuild
@@ -51,4 +51,4 @@ src_configure() {
 		--flag=-bundled-binary-generic
 }
 
-CABAL_CORE_LIB_GHC_PV="PM:8.10.3 PM:8.10.4 PM:8.10.5 PM:9999"
+CABAL_CORE_LIB_GHC_PV="PM:8.10.3 PM:8.10.4 PM:8.10.5 PM:8.10.5-r1 PM:9999"


### PR DESCRIPTION
Fixes #1208 