### PR TITLE
sci-mathematics/agda: Restore longdescription

### DIFF
--- a/sci-mathematics/agda/metadata.xml
+++ b/sci-mathematics/agda/metadata.xml
@@ -12,4 +12,24 @@ False, then the --count-clusters flag triggers an error message.)</flag>
 		<flag name="optimise-heavily">Enable some expensive optimisations when compiling Agda.</flag>
 		<flag name="stdlib">Install the standard library.</flag>
 	</use>
+	<longdescription>
+	  Agda is a dependently typed functional programming language: It has inductive
+	  families, which are similar to Haskell&#39;s GADTs, but they can be indexed by
+	  values and not just types. It also has parameterised modules, mixfix operators,
+	  Unicode characters, and an interactive Emacs interface (the type checker can
+	  assist in the development of your code).
+
+	  Agda is also a proof assistant: It is an interactive system for writing and
+	  checking proofs. Agda is based on intuitionistic type theory, a foundational
+	  system for constructive mathematics developed by the Swedish logician Per
+	  Martin-L&amp;#xf6;f. It has many similarities with other proof assistants based
+	  on dependent types, such as Coq, Epigram and NuPRL.
+
+	  This package includes both a command-line program (agda) and an Emacs mode. If
+	  you want to use the Emacs mode you can set it up by running @agda-mode setup@
+	  (see the README).
+
+	  Note that the Agda package does not follow the package versioning policy,
+	  because it is not intended to be used by third-party packages.
+	</longdescription>
 </pkgmetadata>


### PR DESCRIPTION
After the bump to version 2.6.2, the long description was lost in the Metadata.xml. I simply restored it from the previous ebuild.