### PR TITLE
Fix dev-haskell/hakyll pandoc dependency

### DIFF
--- a/dev-haskell/hakyll/hakyll-4.15.1.0.ebuild
+++ b/dev-haskell/hakyll/hakyll-4.15.1.0.ebuild
@@ -64,8 +64,8 @@ src_prepare() {
 	default
 
 	cabal_chdeps \
-		'pandoc >= 2.11 && < 2.17' 'pandoc >= 2.11' \
-		'pandoc    >= 2.11  && < 2.17' 'pandoc    >= 2.11'
+		'pandoc >= 2.11 && < 2.16' 'pandoc >= 2.11' \
+		'pandoc    >= 2.11  && < 2.16' 'pandoc    >= 2.11'
 }
 
 src_configure() {


### PR DESCRIPTION
Hi,

It looks like the `cabal_chdeps` parameter value is incorrect (https://github.com/jaspervdj/hakyll/blob/v4.15.1.0/hakyll.cabal#L249)
I've fixed chdep parameters to make hakyll build again.