### PR TITLE
dev-haskell/lua: fixed dependency on dev-lang/lua-5.3

### DIFF
--- a/dev-haskell/lua/lua-2.0.2.ebuild
+++ b/dev-haskell/lua/lua-2.0.2.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="+allow-unsafe-gc apicheck +export-dynamic +hardcode-reg-keys lua-32bits"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
-	>=dev-lang/lua-5.3 <dev-lang/lua-5.4
+	dev-lang/lua:5.3
 "
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-2.2.0.1


### PR DESCRIPTION
I have Lua 5.1 and 5.4 installed on my system. The package relies on a system-wide installation of 5.3, which was not pulled in by portage, causing the build to fail. Manually installing 5.3 allowed the build to finish successfully.

The ebuild states:

```bash
RDEPEND=">=dev-lang/ghc-8.4.3:=
	>=dev-lang/lua-5.3 <dev-lang/lua-5.4
"
```

To my understanding, portage considers the two Lua constraints separately, with my installed 5.1 satisfying `<dev-lang/lua-5.4` and my installed 5.4 satisfying `>=dev-lang/lua-5.3`. So I simply merged those two into a single `dev-lang/lua:5.3`. As people affected by this bug should not have a working installation of `dev-haskell/lua`, I did not consider a revision bump necessary.