### PR TITLE
eclass/haskell-cabal.eclass: Switch to --enable-profiling for `profile`

### DIFF
--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -322,7 +322,7 @@ cabal-configure() {
 		fi
 	fi
 	if [[ -n "${CABAL_USE_PROFILE}" ]] && use profile; then
-		cabalconf+=(--enable-library-profiling)
+		cabalconf+=(--enable-profiling)
 	fi
 
 	if [[ -n "${CABAL_TEST_SUITE}" ]]; then

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -4,3 +4,4 @@
 # Keep them sorted
 
 hoogle - generate hoogle database for dev-haskell/hoogle
+profile - build using cabal's --enable-profiling flag


### PR DESCRIPTION
I'm wondering if this is a good idea.

I looked into what the `profile` USE flag does and it turns out it passes the `--enable-library-profiling` flag to cabal during `cabal-configure()`. I [looked it up](https://cabal.readthedocs.io/en/3.2/nix-local-build.html?highlight=enable-profiling#cfg-field-library-profiling) and it seems like `--enable-profiling` should be used instead. After all, many packages that build an executable have the `profile` USE flag as well. But, I've never used any of this so I don't really know.

I also think the description for `profile` should clearly state what it does. Currently, `equery u` does not look at `profiles/use.desc` in overlays, but that might change in the future.