### PR TITLE
Updated link for git book

### DIFF
--- a/projects/doc/README.rst
+++ b/projects/doc/README.rst
@@ -25,7 +25,7 @@ ircs://irc.libera.chat/#gentoo-haskell to get help.
 
 .. _TODO list: TODO.rst
 .. _bug reports: http://tinyurl.com/2l3p48
-.. _some git basics: http://progit.org/book/
+.. _some git basics: https://git-scm.com/book/en/v2 
 
 Introduction to Haskell Ebuilds
 ===============================


### PR DESCRIPTION
Looks like the link for the git book is no longer correct in the developer readme. With this pull request, hopefully I have linked to the correct location for the book!