### PR TITLE
haskell-cabal.eclass: avoid redundant distfile renaming

### DIFF
--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -239,7 +239,11 @@ case $PV in
 	*9999) ;;
 	*)
 		if [[ -z "${CABAL_LIVE_VERSION}" ]]; then
-			SRC_URI="https://hackage.haskell.org/package/${CABAL_P}/${CABAL_P}.tar.gz -> ${P}.tar.gz"
+			if [[ "${CABAL_P}" == "${P}" ]]; then
+				SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
+			else
+				SRC_URI="https://hackage.haskell.org/package/${CABAL_P}/${CABAL_P}.tar.gz -> ${P}.tar.gz"
+			fi
 			if [[ -n ${CABAL_DISTFILE} ]]; then
 				SRC_URI+=" https://hackage.haskell.org/package/${CABAL_P}/revision/${CABAL_HACKAGE_REVISION}.cabal -> ${CABAL_DISTFILE}"
 			fi


### PR DESCRIPTION
pkgcheck complains of redundant distfile renames for any
packages whose ${CABAL_P} is equal to its ${P}. In other
words, all-lowercase packages.

In the spirit of avoiding QA warnings as much as possible,
this small eclass change checks if ${CABAL_P} does not equal
${P} prior to proceeding with renaming the distfile.
Where they are equal, it uses the distfile un-renamed from
upstream. This makes pkgcheck happy.

Signed-off-by: Jack Todaro <solpeth@posteo.org>