### PR TITLE
eclass/haskell-cabal: support for using cabal-9999 (live cabal ebuilds)

### DIFF
--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -267,6 +267,10 @@ cabal-version() {
 			# We ask portage, not ghc, so that we only pick up
 			# portage-installed cabal versions.
 			_CABAL_VERSION_CACHE="$(ghc-extract-pm-version dev-haskell/cabal)"
+			# exception for live (9999) version
+			if [[ "${_CABAL_VERSION_CACHE}" == 9999 ]]; then
+				_CABAL_VERSION_CACHE="$(ghc-cabal-version)"
+			fi
 		fi
 	fi
 	echo "${_CABAL_VERSION_CACHE}"


### PR DESCRIPTION
For using live (9999) cabal and cabal-install versions.

Eclass used to get wrong version of cabal because portage labels it 9999 but ghc knows it's 3.9