### PR TITLE
Updated elm-compiler dependencies

### DIFF
--- a/dev-lang/elm-compiler/elm-compiler-0.19.1-r1.ebuild
+++ b/dev-lang/elm-compiler/elm-compiler-0.19.1-r1.ebuild
@@ -59,7 +59,8 @@ src_prepare() {
 		'ansi-terminal >= 0.8 && < 0.9' 'ansi-terminal >= 0.8' \
 		'containers >= 0.5.8.2 && < 0.6' 'containers >= 0.5.8.2' \
 		'network >= 2.4 && < 2.7' 'network >= 2.4.0.0' \
-		'http-client >= 0.6 && < 0.7' 'http-client >= 0.6 && < 0.8'
+		'http-client >= 0.6 && < 0.7' 'http-client >= 0.6 && < 0.8' \
+		'HTTP >= 4000.2.5 && < 4000.4' 'HTTP >= 4000.2.5'
 
 	# =fail is useful to detect uncached entries
 	export ELM_FETCH_MODE_GENTOO=warn

--- a/dev-lang/elm-compiler/elm-compiler-0.19.1-r1.ebuild
+++ b/dev-lang/elm-compiler/elm-compiler-0.19.1-r1.ebuild
@@ -24,7 +24,7 @@ RDEPEND=" !dev-lang/elm-compiler-bin[symlink]
 	dev-haskell/file-embed:=
 	dev-haskell/filelock:=
 	dev-haskell/haskeline:=
-	>=dev-haskell/http-4000.2.5:= <dev-haskell/http-4000.4:=
+	>=dev-haskell/http-4000.2.5:=
 	>=dev-haskell/http-client-0.6:= <dev-haskell/http-client-0.8:=
 	>=dev-haskell/http-client-tls-0.3:= <dev-haskell/http-client-tls-0.4:=
 	>=dev-haskell/http-types-0.12:= <dev-haskell/http-types-1.0:=


### PR DESCRIPTION
Removed the dependency version upper limit for HTTP. It builds OK and appears to function OK. 

I am also in conversation with the elm team to see how this can be resolved in the elm.cabal file upstream, since this should be causing issues for them as well?

I would quite like to keep this package in the overlay - currently it is marked for removal and hard masked (I do recognise that the elm-compiler-bin package is still present and not masked). I will hopefully resolve the dependencies question to the satisfaction of the core developers to enable this to happen!