### PR TITLE
dev-haskell/http-media: allow newer bytestring

### DIFF
--- a/dev-haskell/http-media/http-media-0.8.0.0.ebuild
+++ b/dev-haskell/http-media/http-media-0.8.0.0.ebuild
@@ -34,6 +34,8 @@ src_prepare() {
 
 	cabal_chdeps \
 		'base             >= 4.7  && < 4.13' 'base             >= 4.8' \
+		'bytestring       >= 0.10 && < 0.11' ' bytestring       >= 0.10' \
 		'base                       >= 4.7  && < 4.13' 'base >= 4.7' \
+		'bytestring                 >= 0.10 && < 0.11' 'bytestring >= 0.10' \
 		'QuickCheck                 >= 2.8  && < 2.14' 'QuickCheck >= 2.8'
 }


### PR DESCRIPTION
builds fine with ghc-9.2.4
revision bump is not an option yet: https://github.com/zmthy/http-media/issues/41