### PR TITLE
dev-haskell/direct-sqlite fix flags

### DIFF
--- a/dev-haskell/direct-sqlite/direct-sqlite-2.3.27.ebuild
+++ b/dev-haskell/direct-sqlite/direct-sqlite-2.3.27.ebuild
@@ -32,7 +32,6 @@ src_configure() {
 	haskell-cabal_src_configure \
 		$(cabal_flag fulltextsearch fulltextsearch) \
 		$(cabal_flag haveusleep haveusleep) \
-		--flag=haveusleep -systemlib \
 		$(cabal_flag json1 json1) \
 		$(cabal_flag systemlib systemlib) \
 		$(cabal_flag urifilenames urifilenames)


### PR DESCRIPTION
`haveusleep` and `systemlib` are interpreted on other lines. Also, `-systemlib` misses `--flag=` prefix, causing configure to fail.