### PR TITLE
app-text/pandoc-cli: profile should be in IUSE

### DIFF
--- a/app-text/pandoc-cli/pandoc-cli-0.1.1.ebuild
+++ b/app-text/pandoc-cli/pandoc-cli-0.1.1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://pandoc.org"
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="+lua nightly +server"
+IUSE="+lua profile nightly +server"
 
 RDEPEND=">=app-text/pandoc-3.0:=
 	dev-haskell/text:=


### PR DESCRIPTION
Currently its impossible to emerge `pandoc-cli` since `ghc` has a conditional `profile?` flag but `IUSE` is missing it. This fixes that.