### PR TITLE
eclass/haskell-cabal: EAPI 7 was dropped from eutils

### DIFF
--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -42,8 +42,8 @@
 
 case ${EAPI} in
 	# eutils is for eqawarn
-	6|7) inherit eutils ;;
-	8) ;;
+	6) inherit eutils ;;
+	8|7) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 


### PR DESCRIPTION
https://github.com/gentoo/gentoo/commit/39c5ef0fe227a4781d1b2ea79ac6f336ec64f879