### PR TITLE
virtual/pandoc:  new package, add 0

### DIFF
--- a/app-text/pandoc-cli/pandoc-cli-0.1.1.ebuild
+++ b/app-text/pandoc-cli/pandoc-cli-0.1.1.ebuild
@@ -26,6 +26,7 @@ RDEPEND=">=dev-haskell/pandoc-3.0:=
 			dev-haskell/safe:=
 			>=dev-haskell/wai-extra-3.0.24:=
 			dev-haskell/warp:= )
+	!app-text/pandoc
 "
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-3.0.0.0

--- a/dev-haskell/pandoc/pandoc-3.1.8.ebuild
+++ b/dev-haskell/pandoc/pandoc-3.1.8.ebuild
@@ -75,6 +75,7 @@ RDEPEND=">=dev-haskell/aeson-2.0.1.0:=[profile?] <dev-haskell/aeson-2.3:=[profil
 	>=dev-haskell/zip-archive-0.4.3:=[profile?] <dev-haskell/zip-archive-0.5:=[profile?]
 	>=dev-haskell/zlib-0.5:=[profile?] <dev-haskell/zlib-0.7:=[profile?]
 	>=dev-lang/ghc-8.10.6:=
+	!app-text/pandoc
 "
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-3.2.1.0

--- a/virtual/pandoc/pandoc-0.ebuild
+++ b/virtual/pandoc/pandoc-0.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Virtual for pandoc"
+
+LICENSE=""
+SLOT="0"
+KEYWORDS="~amd64"
+
+BDEPEND=""
+RDEPEND="|| ( app-text/pandoc-cli app-text/pandoc-bin[pandoc-symlink] <app-text/pandoc-3 )"
+# (`app-text/pandoc-bin` is present upstream in the main `::gentoo` ebuild
+# repository.)


### PR DESCRIPTION
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Adapted from `virtual/pandoc-0::gentoo`.  This is needed to unblock dependents regardless of source ebuild repository.  (For example, see <https://bugs.gentoo.org/913960#c4>.)  
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;~~I've opened this PR as a draft since there may still be a couple issues I have to resolve on it before it's fully ready to review.  Running '`pkgcheck scan`' outputs:~~  

```
virtual/pandoc
  NonsolvableDepsInDev: version 0: nonsolvable depset(rdepend) keyword(~riscv) dev profile (default/linux/riscv/20.0/rv64gc/lp64/desktop) (42 total): solutions: [ app-text/pandoc-bin[pandoc-symlink], app-text/pandoc-cli ]
  NonsolvableDepsInStable: version 0: nonsolvable depset(rdepend) keyword(~riscv) stable profile (default/linux/riscv/20.0/rv64gc/lp64) (38 total): solutions: [ app-text/pandoc-bin[pandoc-symlink], app-text/pandoc-cli ]
  PotentialStable: version 0: slot(0), stabled arch: [ amd64 ], potentials: [ ~arm64, ~riscv, ~x86 ]
```

~~Of these warnings:~~  

 1. ~~The first two are for 64-bit RISC-V.  The machine I'm preparing this pull request from is an x86-64 (AMD64) one, so I guess these diagnostics can just be ignored, right?~~  
 1. ~~The last message looks like it's just a notice that isn't relevant until/unless this overlay starts providing stable packages.~~  

(_Edit:_  All '`pkgcheck scan`' errors have now been taken care of.)  