### PR TITLE
ghc-package.eclass: sync back from ::gentoo, fix  "unknown keyword @AUTHOR:" eclass-to-manpage error

### DIFF
--- a/eclass/ghc-package.eclass
+++ b/eclass/ghc-package.eclass
@@ -1,12 +1,12 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: ghc-package.eclass
 # @MAINTAINER:
 # "Gentoo's Haskell Language team" <haskell@gentoo.org>
-# @SUPPORTED_EAPIS: 6 7 8
 # @AUTHOR:
 # Original Author: Andres Loeh <kosmikus@gentoo.org>
+# @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: This eclass helps with the Glasgow Haskell Compiler's package configuration utility.
 # @DESCRIPTION:
 # Helper eclass to handle ghc installation/upgrade/deinstallation process.


### PR DESCRIPTION
See
https://github.com/gentoo/gentoo/commit/7c9bacebd7254491a72e633b523feacfec72d5ec