### PR TITLE
dev-lang/ghc: switching sys-devel/lllvm to llvm-core/llvm

### DIFF
--- a/dev-lang/ghc/ghc-9.0.2-r4.ebuild
+++ b/dev-lang/ghc/ghc-9.0.2-r4.ebuild
@@ -136,9 +136,9 @@ RDEPEND="
 	!ghcmakebinary? ( dev-libs/libffi:= )
 	numa? ( sys-process/numactl )
 	llvm? (
-		<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+		<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 		|| (
-			sys-devel/llvm:14
+			llvm-core/llvm:14
 		)
 	)
 "

--- a/dev-lang/ghc/ghc-9.10.1-r2.ebuild
+++ b/dev-lang/ghc/ghc-9.10.1-r2.ebuild
@@ -102,12 +102,12 @@ RESTRICT="!test? ( test )"
 
 LLVM_MAX_SLOT="18"
 LLVM_DEPS="
-	<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+	<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 	|| (
-		sys-devel/llvm:15
-		sys-devel/llvm:16
-		sys-devel/llvm:17
-		sys-devel/llvm:18
+		llvm-core/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:17
+		llvm-core/llvm:18
 	)
 "
 

--- a/dev-lang/ghc/ghc-9.2.7-r1.ebuild
+++ b/dev-lang/ghc/ghc-9.2.7-r1.ebuild
@@ -154,9 +154,9 @@ RDEPEND="
 	!ghcmakebinary? ( dev-libs/libffi:= )
 	numa? ( sys-process/numactl )
 	llvm? (
-		<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+		<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 		|| (
-			sys-devel/llvm:14
+			llvm-core/llvm:14
 		)
 	)
 "

--- a/dev-lang/ghc/ghc-9.2.8.ebuild
+++ b/dev-lang/ghc/ghc-9.2.8.ebuild
@@ -145,9 +145,9 @@ RDEPEND="
 	!ghcmakebinary? ( dev-libs/libffi:= )
 	numa? ( sys-process/numactl )
 	llvm? (
-		<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+		<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 		|| (
-			sys-devel/llvm:14
+			llvm-core/llvm:14
 		)
 	)
 "

--- a/dev-lang/ghc/ghc-9.4.7.ebuild
+++ b/dev-lang/ghc/ghc-9.4.7.ebuild
@@ -101,12 +101,12 @@ RESTRICT="!test? ( test )"
 
 LLVM_MAX_SLOT="18"
 LLVM_DEPS="
-	<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+	<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 	|| (
-		sys-devel/llvm:15
-		sys-devel/llvm:16
-		sys-devel/llvm:17
-		sys-devel/llvm:18
+		llvm-core/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:17
+		llvm-core/llvm:18
 	)
 "
 

--- a/dev-lang/ghc/ghc-9.4.8.ebuild
+++ b/dev-lang/ghc/ghc-9.4.8.ebuild
@@ -127,12 +127,12 @@ RESTRICT="!test? ( test )"
 
 LLVM_MAX_SLOT="18"
 LLVM_DEPS="
-	<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+	<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 	|| (
-		sys-devel/llvm:15
-		sys-devel/llvm:16
-		sys-devel/llvm:17
-		sys-devel/llvm:18
+		llvm-core/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:17
+		llvm-core/llvm:18
 	)
 "
 

--- a/dev-lang/ghc/ghc-9.6.3-r1.ebuild
+++ b/dev-lang/ghc/ghc-9.6.3-r1.ebuild
@@ -102,12 +102,12 @@ RESTRICT="!test? ( test )"
 
 LLVM_MAX_SLOT="18"
 LLVM_DEPS="
-	<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+	<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 	|| (
-		sys-devel/llvm:15
-		sys-devel/llvm:16
-		sys-devel/llvm:17
-		sys-devel/llvm:18
+		llvm-core/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:17
+		llvm-core/llvm:18
 	)
 "
 

--- a/dev-lang/ghc/ghc-9.6.4-r1.ebuild
+++ b/dev-lang/ghc/ghc-9.6.4-r1.ebuild
@@ -102,12 +102,12 @@ RESTRICT="!test? ( test )"
 
 LLVM_MAX_SLOT="18"
 LLVM_DEPS="
-	<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+	<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 	|| (
-		sys-devel/llvm:15
-		sys-devel/llvm:16
-		sys-devel/llvm:17
-		sys-devel/llvm:18
+		llvm-core/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:17
+		llvm-core/llvm:18
 	)
 "
 

--- a/dev-lang/ghc/ghc-9.6.5.ebuild
+++ b/dev-lang/ghc/ghc-9.6.5.ebuild
@@ -101,12 +101,12 @@ RESTRICT="!test? ( test )"
 
 LLVM_MAX_SLOT="18"
 LLVM_DEPS="
-	<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+	<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 	|| (
-		sys-devel/llvm:15
-		sys-devel/llvm:16
-		sys-devel/llvm:17
-		sys-devel/llvm:18
+		llvm-core/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:17
+		llvm-core/llvm:18
 	)
 "
 

--- a/dev-lang/ghc/ghc-9.6.6.ebuild
+++ b/dev-lang/ghc/ghc-9.6.6.ebuild
@@ -101,12 +101,12 @@ RESTRICT="!test? ( test )"
 
 LLVM_MAX_SLOT="18"
 LLVM_DEPS="
-	<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+	<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 	|| (
-		sys-devel/llvm:15
-		sys-devel/llvm:16
-		sys-devel/llvm:17
-		sys-devel/llvm:18
+		llvm-core/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:17
+		llvm-core/llvm:18
 	)
 "
 

--- a/dev-lang/ghc/ghc-9.8.2-r2.ebuild
+++ b/dev-lang/ghc/ghc-9.8.2-r2.ebuild
@@ -110,12 +110,12 @@ RESTRICT="!test? ( test )"
 
 LLVM_MAX_SLOT="18"
 LLVM_DEPS="
-	<sys-devel/llvm-$((${LLVM_MAX_SLOT} + 1)):=
+	<llvm-core/llvm-$((${LLVM_MAX_SLOT} + 1)):=
 	|| (
-		sys-devel/llvm:15
-		sys-devel/llvm:16
-		sys-devel/llvm:17
-		sys-devel/llvm:18
+		llvm-core/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:17
+		llvm-core/llvm:18
 	)
 "
 


### PR DESCRIPTION
LLVM has moved from sys-devel to llvm-core. Reflecting that in the ghc ebuilds.