### PR TITLE
change old references to sys-devel/clang to llvm-core/clang in 4 packages

### DIFF
--- a/dev-haskell/double-conversion/double-conversion-2.0.5.0.ebuild
+++ b/dev-haskell/double-conversion/double-conversion-2.0.5.0.ebuild
@@ -19,7 +19,7 @@ KEYWORDS="~amd64"
 RDEPEND=">=dev-haskell/text-0.11.0.8:=[profile?]
 	>=dev-lang/ghc-9.0.2:=
 	dev-libs/double-conversion
-	|| ( sys-devel/clang
+	|| ( llvm-core/clang
 		sys-devel/gcc[cxx] )
 "
 DEPEND="${RDEPEND}

--- a/dev-haskell/ghc-debug-stub/ghc-debug-stub-0.6.0.0.ebuild
+++ b/dev-haskell/ghc-debug-stub/ghc-debug-stub-0.6.0.0.ebuild
@@ -18,7 +18,7 @@ IUSE="eras trace"
 
 RDEPEND="~dev-haskell/ghc-debug-convention-0.6.0.0:=[profile?]
 	>=dev-lang/ghc-9.2.4:=
-	|| ( sys-devel/clang
+	|| ( llvm-core/clang
 		sys-devel/gcc[cxx] )
 "
 DEPEND="${RDEPEND}

--- a/dev-haskell/text/text-2.0.2.ebuild
+++ b/dev-haskell/text/text-2.0.2.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-lang/ghc-9.4.1:=
 	simdutf? (
 		|| (
-			sys-devel/clang
+			llvm-core/clang
 			sys-devel/gcc[cxx]
 		)
 	)

--- a/dev-haskell/text/text-2.1.1.ebuild
+++ b/dev-haskell/text/text-2.1.1.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-lang/ghc-9.4.1:=
 	simdutf? (
 		|| (
-			sys-devel/clang
+			llvm-core/clang
 			sys-devel/gcc[cxx]
 		)
 	)

--- a/dev-haskell/tidal-link/tidal-link-1.0.3.ebuild
+++ b/dev-haskell/tidal-link/tidal-link-1.0.3.ebuild
@@ -25,7 +25,7 @@ CABAL_CHBINS=(
 )
 
 RDEPEND=">=dev-lang/ghc-9.0.2:=
-	|| ( sys-devel/clang
+	|| ( llvm-core/clang
 		sys-devel/gcc[cxx] )
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Ran into some issues updating haskell-language-server as (some versions of) `dev-haskell/text` and `dev-haskell/double-conversation` still reference sys-devel/clang.
This changes those two packages, along with `dev-haskell/ghc-debug-stub` and `dev-haskell/tidal-link` which both also have the same issues.
Was considering adding -r1 to the versions, but after looking at a few examples from the main gentoo repo it looks like that isn't necessary for package name updates.