### PR TITLE
dev-lang/ghc: port Fix CPP guards around ghc_unique_counter64

### DIFF
--- a/dev-lang/ghc/files/ghc-9.12.1-cpp-guard-fix.patch
+++ b/dev-lang/ghc/files/ghc-9.12.1-cpp-guard-fix.patch
@@ -1,0 +1,41 @@
+From e421ec3c8fc9688b3f7ee08c0d1baaf1cb7aa750 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@well-typed.com>
+Date: Tue, 17 Dec 2024 11:48:52 -0500
+Subject: [PATCH] compiler: Fix CPP guards around ghc_unique_counter64
+
+The `ghc_unique_counter64` symbol was introduced in the RTS in the
+64-bit unique refactor (!10568) which has been backported to %9.6.7 and
+%9.8.4. Update the CPP to reflect this.
+
+Fixes #25576.
+---
+ compiler/cbits/genSym.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/compiler/cbits/genSym.c b/compiler/cbits/genSym.c
+index 3f7e2266c43d..469855561284 100644
+--- a/compiler/cbits/genSym.c
++++ b/compiler/cbits/genSym.c
+@@ -9,6 +9,18 @@
+ //
+ // The CPP is thus about the RTS version GHC is linked against, and not the
+ // version of the GHC being built.
+-#if !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)
++
++#if MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)
++// Unique64 patch was present in 9.10 and later
++#define HAVE_UNIQUE64 1
++#elif !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0) && MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)
++// Unique64 patch was backported to 9.8.4
++#define HAVE_UNIQUE64 1
++#elif !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0) && MIN_VERSION_GLASGOW_HASKELL(9,6,7,0)
++// Unique64 patch was backported to 9.6.7
++#define HAVE_UNIQUE64 1
++#endif
++
++#if !defined(HAVE_UNIQUE64)
+ HsWord64 ghc_unique_counter64 = 0;
+ #endif
+-- 
+GitLab
+

--- a/dev-lang/ghc/ghc-9.12.1-r1.ebuild
+++ b/dev-lang/ghc/ghc-9.12.1-r1.ebuild
@@ -567,6 +567,9 @@ src_prepare() {
 
 	cd "${S}" # otherwise eapply will break
 
+	# https://github.com/gentoo-haskell/gentoo-haskell/issues/1585
+	eapply "${FILESDIR}/${PN}-9.12.1-cpp-guard-fix.patch"
+
 	eapply "${FILESDIR}"/${PN}-9.12.1-allow-cross-bootstrap.patch
 
 	# https://gitlab.haskell.org/ghc/ghc/-/issues/22954


### PR DESCRIPTION
fixes #1585 (maybe)