### PR TITLE
scripts/package.unmask: loosening mask on cabal

### DIFF
--- a/scripts/package.unmask/ghc-9.8
+++ b/scripts/package.unmask/ghc-9.8
@@ -1,8 +1,8 @@
 <dev-lang/ghc-9.9
 <dev-haskell/hadrian-9.9
-<dev-haskell/cabal-3.10.4
-<dev-haskell/cabal-fmt-0.1.12
-<dev-haskell/cabal-syntax-3.10.4
+<dev-haskell/cabal-3.13
+<dev-haskell/cabal-fmt-0.1.13
+<dev-haskell/cabal-syntax-3.13
 <dev-haskell/cabal-described-3.10.4
 <dev-haskell/cabal-quickcheck-3.10.4
 <dev-haskell/cabal-install-solver-3.10.4


### PR DESCRIPTION
Ghc-9.8 needs cabal-fmt-0.1.12, which needs cabal 3.12 and cabal-syntax 3.12
<!-- Please put the pull request description above -->
<!-- This template has been copied verbatim from the main Gentoo repository. -->

---

Please check all the boxes that apply:

- [ X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
