### PR TITLE
scripts/package.unmask: ghc-9.6, stricter mask on haddock

### DIFF
--- a/scripts/package.unmask/ghc-9.6
+++ b/scripts/package.unmask/ghc-9.6
@@ -28,8 +28,8 @@
 <dev-haskell/ghc-lib-parser-9.11
 <dev-haskell/ghc-lib-parser-ex-9.11
 <dev-haskell/stylish-haskell-0.15
-<dev-haskell/haddock-2.30
-<dev-haskell/haddock-api-2.30
+<dev-haskell/haddock-2.29.2
+<dev-haskell/haddock-api-2.29.2
 <dev-haskell/hlint-3.9
 <dev-haskell/hoauth2-2.14
 <dev-haskell/stack-2.14


### PR DESCRIPTION
dev-haskell/haddock-2.29.2 requires ghc>=9.8

(p.s.: note that there is actually no such thing as haddock-2.29.2 on hackage, this was a workaround by hololeap)
<!-- Please put the pull request description above -->
<!-- This template has been copied verbatim from the main Gentoo repository. -->

---

Please check all the boxes that apply:

- [ x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
