### PR TITLE
dev-haskell/gtk: reinstating GHC_BOOTSTRAP_PACKAGES

### DIFF
--- a/dev-haskell/gtk/gtk-0.15.9.ebuild
+++ b/dev-haskell/gtk/gtk-0.15.9.ebuild
@@ -17,6 +17,10 @@ SLOT="0/${PV}"
 KEYWORDS="~amd64"
 IUSE="+deprecated +fmode-binary +gio"
 
+GHC_BOOTSTRAP_PACKAGES=(
+		gtk2hs-buildtools
+	)
+
 RDEPEND=">=dev-haskell/cairo-0.13.0.0:=[profile?] <dev-haskell/cairo-0.14:=[profile?]
 	>=dev-haskell/glib-0.13.0.0:=[profile?] <dev-haskell/glib-0.14:=[profile?]
 	>=dev-haskell/pango-0.13.0.0:=[profile?] <dev-haskell/pango-0.14:=[profile?]


### PR DESCRIPTION
Fixing a mistake in a previous commit. These lines should not have been dropped.

I’m awfully sorry for that
<!-- Please put the pull request description above -->
<!-- This template has been copied verbatim from the main Gentoo repository. -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
