### PR TITLE
dev-haskell/byline: patch fix

### DIFF
--- a/dev-haskell/byline/byline-1.1.2-r1.ebuild
+++ b/dev-haskell/byline/byline-1.1.2-r1.ebuild
@@ -28,14 +28,6 @@ PATCHES=(
 	"${FILESDIR}"/byline-1.1.2-optparse-applicative-0.18.patch
 	)
 
-CABAL_CHDEPS=(
-	'optparse-applicative  ^>=0.17' 'optparse-applicative >=0.18'
-	'ansi-terminal         >=0.6  && <0.12' 'ansi-terminal >=0.6'
-	'free                  ^>=5.1' 'free >=5.1'
-	'relude                >=0.6  && <1.2' 'relude >=0.6'
-	'text                  >=0.11 && <2.1' 'text >=0.11'
-)
-
 RDEPEND="
 	>=dev-haskell/ansi-terminal-0.6:=[profile?]
 	>=dev-haskell/attoparsec-0.13:=[profile?] <dev-haskell/attoparsec-0.15:=[profile?]

--- a/dev-haskell/byline/files/byline-1.1.2-optparse-applicative-0.18.patch
+++ b/dev-haskell/byline/files/byline-1.1.2-optparse-applicative-0.18.patch
@@ -21,7 +21,8 @@ Subject: [PATCH] Optparse-applicative-0.18 support
      , mtl                   >=2.1  && <2.4
 -    , optparse-applicative  ^>=0.17
 +    , optparse-applicative  ^>=0.18
-     , relude                >=0.6  && <1.3
+-    , relude                >=0.6  && <1.2
++    , relude                >=0.6  && <1.3
      , terminfo-hs           >=0.1  && <0.3
 -    , text                  >=0.11 && <2.1
 +    , text                  >=0.11 && <2.2


### PR DESCRIPTION
When we moved from the local patch to the one submitted upstream, I overlooked the fact that some of the bits of the upstream patch were initially taken care of in CABAL_CHDEPS here, so the package was broken. This fixes it.
<!-- Please put the pull request description above -->
<!-- This template has been copied verbatim from the main Gentoo repository. -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
