### PR TITLE
dev-haskell/influxdb: loosening deps

### DIFF
--- a/dev-haskell/influxdb/influxdb-1.9.3.2.ebuild
+++ b/dev-haskell/influxdb/influxdb-1.9.3.2.ebuild
@@ -15,6 +15,7 @@ LICENSE="BSD"
 SLOT="0/${PV}"
 KEYWORDS="~amd64"
 IUSE="examples"
+RESTRICT+="test" #requires a running influxdb instance
 
 RDEPEND=">=dev-haskell/aeson-0.7:=[profile?] <dev-haskell/aeson-2.3:=[profile?]
 	<dev-haskell/attoparsec-0.15:=[profile?]
@@ -38,7 +39,7 @@ RDEPEND=">=dev-haskell/aeson-0.7:=[profile?] <dev-haskell/aeson-2.3:=[profile?]
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-3.4.1.0 <dev-haskell/cabal-3.13
 	>=dev-haskell/cabal-doctest-1 <dev-haskell/cabal-doctest-1.1
-	test? ( >=dev-haskell/doctest-0.11.3 <dev-haskell/doctest-0.23
+	test? ( >=dev-haskell/doctest-0.11.3 <dev-haskell/doctest-0.24
 		>=dev-haskell/raw-strings-qq-1.1 <dev-haskell/raw-strings-qq-1.2
 		<dev-haskell/tasty-1.6
 		<dev-haskell/tasty-hunit-1.11 )


### PR DESCRIPTION
I'm currently unable to run tests on this, not because they don't work, but because I cannot, for the life of me, get a version of influxdb that accepts to talk with this package, whether the pre-loosening or post-loosening version, and whichever version of ghc I use.

I have never used influxdb, the package only works with <influxdb-2.0, and I can only find doc for >=influxdb-2.0 online. Happy for some pointers.

<!-- Please put the pull request description above -->
<!-- This template has been copied verbatim from the main Gentoo repository. -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
