### PR TITLE
dev-haskell/yesod-core: patch for wai-extra

### DIFF
--- a/dev-haskell/yesod-core/files/yesod-core-1.6.26.0-wai-extra.patch
+++ b/dev-haskell/yesod-core/files/yesod-core-1.6.26.0-wai-extra.patch
@@ -1,0 +1,84 @@
+FROM https://github.com/yesodweb/yesod/pull/1861/commits/26ba3db77227bf6c3f9aa590eefb78e346cb52b1
+From: Felix Paulusma <felix.paulusma@gmail.com>
+Date: Sun, 2 Mar 2025 19:36:53 +0100
+Subject: [PATCH] yesod-core: Dispatch builds with 'wai-extra >= 3.0.7' again
+
+--- a/src/Yesod/Core/Dispatch.hs
++++ b/src/Yesod/Core/Dispatch.hs
+@@ -1,8 +1,9 @@
+-{-# LANGUAGE TemplateHaskell #-}
+-{-# LANGUAGE OverloadedStrings #-}
+-{-# LANGUAGE TypeFamilies #-}
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE FlexibleInstances #-}
+ {-# LANGUAGE MultiParamTypeClasses #-}
++{-# LANGUAGE OverloadedStrings #-}
++{-# LANGUAGE TemplateHaskell #-}
++{-# LANGUAGE TypeFamilies #-}
+ module Yesod.Core.Dispatch
+     ( -- * Quasi-quoted routing
+       parseRoutes
+@@ -63,6 +64,9 @@ import qualified Data.ByteString as S
+ import qualified Data.ByteString.Lazy as BL
+ import qualified Data.ByteString.Char8 as S8
+ import Data.ByteString.Builder (byteString, toLazyByteString)
++#if !MIN_VERSION_wai_extra(3,1,14)
++import Data.Default (def)
++#endif
+ import Network.HTTP.Types (status301, status307)
+ import Yesod.Routes.Parse
+ import Yesod.Core.Types
+@@ -78,7 +82,12 @@ import Yesod.Core.Internal.Util (getCurrentMaxExpiresRFC1123)
+ import Network.Wai.Middleware.Autohead
+ import Network.Wai.Middleware.AcceptOverride
+ import Network.Wai.Middleware.RequestLogger
+-import Network.Wai.Middleware.Gzip
++import Network.Wai.Middleware.Gzip (
++    gzip,
++#if MIN_VERSION_wai_extra(3,1,14)
++    defaultGzipSettings,
++#endif
++ )
+ import Network.Wai.Middleware.MethodOverride
+ 
+ import qualified Network.Wai.Handler.Warp
+@@ -244,7 +253,12 @@ serverValue = S8.pack $ concat
+ -- Since 1.2.0
+ mkDefaultMiddlewares :: Logger -> IO W.Middleware
+ mkDefaultMiddlewares logger = do
+-    logWare <- mkRequestLogger def
++    logWare <- mkRequestLogger
++#if MIN_VERSION_wai_extra(3,1,8)
++        defaultRequestLoggerSettings
++#else
++        def
++#endif
+         { destination = Network.Wai.Middleware.RequestLogger.Logger $ loggerSet logger
+         , outputFormat = Apache FromSocket
+         }
+@@ -254,7 +268,14 @@ mkDefaultMiddlewares logger = do
+ --
+ -- Since 1.2.12
+ defaultMiddlewaresNoLogging :: W.Middleware
+-defaultMiddlewaresNoLogging = acceptOverride . autohead . gzip def . methodOverride
++defaultMiddlewaresNoLogging = acceptOverride . autohead . gzip gzipSettings . methodOverride
++  where
++    gzipSettings =
++#if MIN_VERSION_wai_extra(3,1,14)
++        defaultGzipSettings
++#else
++        def
++#endif
+ 
+ -- | Deprecated synonym for 'warp'.
+ warpDebug :: YesodDispatch site => Int -> site -> IO ()
+--- a/yesod-core.cabal
++++ b/yesod-core.cabal
+@@ -39,6 +39,7 @@ library
+                    , conduit-extra
+                    , containers            >= 0.2
+                    , cookie                >= 0.4.3    && < 0.6
++                   , data-default
+                    , deepseq               >= 1.3
+                    , entropy
+                    , fast-logger           >= 2.2

--- a/dev-haskell/yesod-core/yesod-core-1.6.26.0.ebuild
+++ b/dev-haskell/yesod-core/yesod-core-1.6.26.0.ebuild
@@ -17,6 +17,14 @@ LICENSE="MIT"
 SLOT="0/${PV}"
 KEYWORDS="~amd64"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-wai-extra.patch
+	)
+
+CABAL_CHDEPS=(
+	'wai-extra             >= 3.0.7    && < 3.1.17' 'wai-extra >= 3.0.7'
+	)
+
 RDEPEND=">=dev-haskell/aeson-1.0:=[profile?]
 	>=dev-haskell/attoparsec-aeson-2.1:=[profile?]
 	dev-haskell/auto-update:=[profile?]
@@ -45,7 +53,7 @@ RDEPEND=">=dev-haskell/aeson-1.0:=[profile?]
 	>=dev-haskell/unordered-containers-0.2:=[profile?]
 	>=dev-haskell/vector-0.9:=[profile?] <dev-haskell/vector-0.14:=[profile?]
 	>=dev-haskell/wai-3.2:=[profile?]
-	>=dev-haskell/wai-extra-3.0.7:=[profile?] <dev-haskell/wai-extra-3.1.17:=[profile?]
+	>=dev-haskell/wai-extra-3.0.7:=[profile?]
 	>=dev-haskell/wai-logger-0.2:=[profile?]
 	>=dev-haskell/warp-3.0.2:=[profile?]
 	dev-haskell/word8:=[profile?]


### PR DESCRIPTION
#1642 

putting this one up alone as if I’m not mistaken it was blocking c. 25 other packages
<!-- Please put the pull request description above -->
<!-- This template has been copied verbatim from the main Gentoo repository. -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
