### PR TITLE
dev-lang/ghc: Add clang as a llvm dep

### DIFF
--- a/dev-lang/ghc/ghc-9.10.1-r6.ebuild
+++ b/dev-lang/ghc/ghc-9.10.1-r6.ebuild
@@ -129,6 +129,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.12.1-r2.ebuild
+++ b/dev-lang/ghc/ghc-9.12.1-r2.ebuild
@@ -137,6 +137,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.12.2.ebuild
+++ b/dev-lang/ghc/ghc-9.12.2.ebuild
@@ -132,6 +132,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.2.7-r1.ebuild
+++ b/dev-lang/ghc/ghc-9.2.7-r1.ebuild
@@ -161,6 +161,7 @@ RDEPEND="
 		|| (
 			llvm-core/llvm:14
 		)
+		llvm-core/clang
 	)
 "
 

--- a/dev-lang/ghc/ghc-9.2.8.ebuild
+++ b/dev-lang/ghc/ghc-9.2.8.ebuild
@@ -152,6 +152,7 @@ RDEPEND="
 		|| (
 			llvm-core/llvm:14
 		)
+		llvm-core/clang
 	)
 "
 

--- a/dev-lang/ghc/ghc-9.4.7.ebuild
+++ b/dev-lang/ghc/ghc-9.4.7.ebuild
@@ -112,6 +112,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.4.8.ebuild
+++ b/dev-lang/ghc/ghc-9.4.8.ebuild
@@ -138,6 +138,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.6.3-r1.ebuild
+++ b/dev-lang/ghc/ghc-9.6.3-r1.ebuild
@@ -113,6 +113,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.6.4-r1.ebuild
+++ b/dev-lang/ghc/ghc-9.6.4-r1.ebuild
@@ -113,6 +113,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.6.5.ebuild
+++ b/dev-lang/ghc/ghc-9.6.5.ebuild
@@ -112,6 +112,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.6.6.ebuild
+++ b/dev-lang/ghc/ghc-9.6.6.ebuild
@@ -142,6 +142,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.8.2-r4.ebuild
+++ b/dev-lang/ghc/ghc-9.8.2-r4.ebuild
@@ -129,6 +129,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.8.3-r1.ebuild
+++ b/dev-lang/ghc/ghc-9.8.3-r1.ebuild
@@ -120,6 +120,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="

--- a/dev-lang/ghc/ghc-9.8.4.ebuild
+++ b/dev-lang/ghc/ghc-9.8.4.ebuild
@@ -142,6 +142,7 @@ LLVM_DEPS="
 		llvm-core/llvm:18
 		llvm-core/llvm:19
 	)
+	llvm-core/clang
 "
 
 RDEPEND="


### PR DESCRIPTION
At the very least, 9.10.1 requires clang to build with `USE=llvm`. Adding `llvm-core/clang` as a dependency for `USE=llvm` for all versions, just to be safe.

<!-- Please put the pull request description above -->
<!-- This template has been copied verbatim from the main Gentoo repository. -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
