### PR TITLE
haskell-updater: Fix prefix patching

### DIFF
--- a/app-admin/haskell-updater/haskell-updater-1.5.0.0.ebuild
+++ b/app-admin/haskell-updater/haskell-updater-1.5.0.0.ebuild
@@ -34,10 +34,10 @@ src_prepare() {
 
 	if use prefix; then
 		sed -i -e "s,/var/db/pkg,${EPREFIX}&,g" \
-			"${S}/Distribution/Gentoo/Packages.hs" || die
+			"${S}/src/Distribution/Gentoo/Packages.hs" || die
 
 		sed -i -e 's,"/","'"${EPREFIX}"'/",g' \
-			"${S}/Distribution/Gentoo/GHC.hs" || die
+			"${S}/src/Distribution/Gentoo/GHC.hs" || die
 	fi
 }
 

--- a/app-admin/haskell-updater/haskell-updater-9999.ebuild
+++ b/app-admin/haskell-updater/haskell-updater-9999.ebuild
@@ -32,10 +32,10 @@ src_prepare() {
 
 	if use prefix; then
 		sed -i -e "s,/var/db/pkg,${EPREFIX}&,g" \
-			"${S}/Distribution/Gentoo/Packages.hs" || die
+			"${S}/src/Distribution/Gentoo/Packages.hs" || die
 
 		sed -i -e 's,"/","'"${EPREFIX}"'/",g' \
-			"${S}/Distribution/Gentoo/GHC.hs" || die
+			"${S}/src/Distribution/Gentoo/GHC.hs" || die
 	fi
 
 	sed -e 's/^version:.*/&.9999/' -i ${PN}.cabal || die # just to distinct from release install


### PR DESCRIPTION
Hello,
This fixes the build with gentoo prefix.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
