### PR TITLE
git-annex: Install git-remote-annex symlink

### DIFF
--- a/dev-vcs/git-annex/git-annex-10.20260601.ebuild
+++ b/dev-vcs/git-annex/git-annex-10.20260601.ebuild
@@ -150,4 +150,5 @@ src_install() {
 	# See: <https://github.com/gentoo-haskell/gentoo-haskell/issues/1491>
 	dosym git-annex /usr/bin/git-annex-shell
 	dosym git-annex /usr/bin/git-remote-tor-annex
+	dosym git-annex /usr/bin/git-remote-annex
 }


### PR DESCRIPTION
Hello,
This adds the missing symlink for git-remote-annex.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
